### PR TITLE
Added Copy with requested Permissions

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -71,12 +71,16 @@ func TestCopy(t *testing.T) {
 	})
 
 	When(t, "try to copy a directory that has no write permission and copy file inside along with it", func(t *testing.T) {
-		err := Copy("testdata/case05", "testdata.copy/case05")
+		src := "testdata/case05"
+		dest := "testdata.copy/case05"
+		err := os.Chmod(src, os.FileMode(0555))
 		Expect(t, err).ToBe(nil)
-		info, err := os.Lstat("testdata.copy/case05")
+		err = Copy(src, dest)
+		Expect(t, err).ToBe(nil)
+		info, err := os.Lstat(dest)
 		Expect(t, err).ToBe(nil)
 		Expect(t, info.Mode().Perm()).ToBe(os.FileMode(0555))
-		err = os.Chmod("testdata.copy/case05", 0755)
+		err = os.Chmod(dest, 0755)
 		Expect(t, err).ToBe(nil)
 	})
 }

--- a/all_test.go
+++ b/all_test.go
@@ -73,5 +73,10 @@ func TestCopy(t *testing.T) {
 	When(t, "try to copy a directory that has no write permission and copy file inside along with it", func(t *testing.T) {
 		err := Copy("testdata/case05", "testdata.copy/case05")
 		Expect(t, err).ToBe(nil)
+		info, err := os.Lstat("testdata.copy/case05")
+		Expect(t, err).ToBe(nil)
+		Expect(t, info.Mode().Perm()).ToBe(os.FileMode(0555))
+		err = os.Chmod("testdata.copy/case05", 0755)
+		Expect(t, err).ToBe(nil)
 	})
 }

--- a/all_test.go
+++ b/all_test.go
@@ -69,70 +69,9 @@ func TestCopy(t *testing.T) {
 		err = Copy("testdata/case04/README.md", "testdata/case04/README.md/foobar")
 		Expect(t, err).Not().ToBe(nil)
 	})
-}
 
-func TestPerm(t *testing.T) {
-
-	//Remove from dirs from previous tests
-	os.RemoveAll("./testdata.copy/")
-
-	err := Perm("./testdata/case00", "./testdata.copy/case00", 0777, 0644)
-	Expect(t, err).ToBe(nil)
-	info, err := os.Stat("./testdata.copy/case00/README.md")
-	Expect(t, err).ToBe(nil)
-	Expect(t, info.IsDir()).ToBe(false)
-
-	When(t, "specified src doesn't exist", func(t *testing.T) {
-		err := Perm("NOT/EXISTING/SOURCE/PATH", "anywhere", 0777, 0444)
-		Expect(t, err).Not().ToBe(nil)
-	})
-
-	When(t, "specified src is just a file", func(t *testing.T) {
-		err := Perm("testdata/case01/README.md", "testdata.copy/case01/README.md", 0777, 0444)
+	When(t, "try to copy a directory that has no write permission and copy file inside along with it", func(t *testing.T) {
+		err := Copy("testdata/case05", "testdata.copy/case05")
 		Expect(t, err).ToBe(nil)
 	})
-
-	When(t, "too long name is given", func(t *testing.T) {
-		dest := "foobar"
-		for i := 0; i < 8; i++ {
-			dest = dest + dest
-		}
-		err := Perm("testdata/case00", filepath.Join("testdata/case00", dest), 0777, 0644)
-		Expect(t, err).Not().ToBe(nil)
-		Expect(t, err).TypeOf("*os.PathError")
-	})
-
-	When(t, "try to create not permitted location", func(t *testing.T) {
-		err := Perm("testdata/case00", "/case00", 0777, 0644)
-		Expect(t, err).Not().ToBe(nil)
-		Expect(t, err).TypeOf("*os.PathError")
-	})
-
-	When(t, "try to create a directory on existing file name", func(t *testing.T) {
-		err := Perm("testdata/case02", "testdata.copy/case00/README.md", 0777, 0644)
-		Expect(t, err).Not().ToBe(nil)
-		Expect(t, err).TypeOf("*os.PathError")
-	})
-
-	When(t, "source directory includes symbolic link", func(t *testing.T) {
-		err := Perm("testdata/case03", "testdata.copy/case03", 0777, 0644)
-		Expect(t, err).ToBe(nil)
-		info, err := os.Lstat("testdata.copy/case03/case01")
-		Expect(t, err).ToBe(nil)
-		Expect(t, info.Mode()&os.ModeSymlink).Not().ToBe(0)
-	})
-
-	When(t, "try to copy a file to existing path", func(t *testing.T) {
-		err := Perm("testdata/case04/README.md", "testdata/case04", 0777, 0644)
-		Expect(t, err).Not().ToBe(nil)
-		err = Perm("testdata/case04/README.md", "testdata/case04/README.md/foobar", 0777, 0644)
-		Expect(t, err).Not().ToBe(nil)
-	})
-
-	When(t, "try to copy into a directory with only read perm", func(t *testing.T) {
-		err := Perm("testdata/case05", "testdata.copy/case05/README.md", 0555, 0644)
-		Expect(t, err).Not().ToBe(nil)
-		Expect(t, err).TypeOf("*os.PathError")
-	})
-
 }

--- a/copy.go
+++ b/copy.go
@@ -75,7 +75,7 @@ func dcopy(srcdir, destdir string, info os.FileInfo) error {
 	}
 
 	// Change dest dir filemode while copying into it
-	if err = os.Chmod(destdir, 0755); err != nil {
+	if err = os.Chmod(destdir, os.FileMode(0755)); err != nil {
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module copy
+
+require (
+	bou.ke/monkey v1.0.1 // indirect
+	github.com/otiai10/mint v1.2.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+bou.ke/monkey v1.0.1 h1:zEMLInw9xvNakzUUPjfS4Ds6jYPqCFx3m7bRmG5NH2U=
+bou.ke/monkey v1.0.1/go.mod h1:FgHuK96Rv2Nlf+0u1OOVDpCMdsWyOFmeeketDHE7LIg=
+github.com/otiai10/mint v1.2.1 h1:vDQzXgHumrrZvJp/ftsTB3NUaZQzjEh7HV7Hx27lZj4=
+github.com/otiai10/mint v1.2.1/go.mod h1:YnfyPNhBvnY8bW4SGQHCs/aAFhkgySlMZbrF5U0bOVw=


### PR DESCRIPTION
In case someone wants to change file and directory permissions upon copying there's a new func `Perm(src, dest string, dirPerm, filePerm os.FileMode) error` which sets dirPerm for all copied directories and filePerfm for all copied files. 

I came upon the problem that in go modules loaded via `go get` files and directories have different permissions than in github. So I had to come up with this solution to be able to load from a template folder with the correct dest permissions independent from the src permissions.