### PR TITLE
Add capability to add permission: Options.AddPermission

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -173,4 +173,27 @@ func TestCopy(t *testing.T) {
 		Expect(t, info).Not().ToBe(nil)
 		Expect(t, err).ToBe(nil)
 	})
+
+	When(t, "Options.AddPermission provided", func(t *testing.T) {
+
+		info, err := os.Stat("testdata/case07/dir_0500")
+		Expect(t, err).ToBe(nil)
+		Expect(t, info.Mode()).ToBe(os.FileMode(0500) | os.ModeDir)
+
+		info, err = os.Stat("testdata/case07/file_0444")
+		Expect(t, err).ToBe(nil)
+		Expect(t, info.Mode()).ToBe(os.FileMode(0444))
+
+		opt := Options{AddPermission: 0200}
+		err = Copy("testdata/case07", "testdata.copy/case07", opt)
+		Expect(t, err).ToBe(nil)
+
+		info, err = os.Stat("testdata.copy/case07/dir_0500")
+		Expect(t, err).ToBe(nil)
+		Expect(t, info.Mode()).ToBe(os.FileMode(0500|0200) | os.ModeDir)
+
+		info, err = os.Stat("testdata.copy/case07/file_0444")
+		Expect(t, err).ToBe(nil)
+		Expect(t, info.Mode()).ToBe(os.FileMode(0444 | 0200))
+	})
 }

--- a/all_test.go
+++ b/all_test.go
@@ -19,6 +19,8 @@ func TestMain(m *testing.M) {
 func setup(m *testing.M) {
 	os.MkdirAll("testdata.copy", os.ModePerm)
 	os.Symlink("testdata/case01", "testdata/case03/case01")
+	os.Chmod("testdata/case07/dir_0500", 0500)
+	os.Chmod("testdata/case07/file_0444", 0444)
 }
 
 func teardown(m *testing.M) {

--- a/copy.go
+++ b/copy.go
@@ -39,13 +39,13 @@ func copy(src, dest string, info os.FileInfo, opt Options) error {
 	if info.IsDir() {
 		return dcopy(src, dest, info, opt)
 	}
-	return fcopy(src, dest, info)
+	return fcopy(src, dest, info, opt)
 }
 
 // fcopy is for just a file,
 // with considering existence of parent directory
 // and file permission.
-func fcopy(src, dest string, info os.FileInfo) (err error) {
+func fcopy(src, dest string, info os.FileInfo, opt Options) (err error) {
 
 	if err := os.MkdirAll(filepath.Dir(dest), os.ModePerm); err != nil {
 		return err
@@ -57,7 +57,7 @@ func fcopy(src, dest string, info os.FileInfo) (err error) {
 	}
 	defer fclose(f, &err)
 
-	if err = os.Chmod(f.Name(), info.Mode()); err != nil {
+	if err = os.Chmod(f.Name(), info.Mode()|opt.AddPermission); err != nil {
 		return err
 	}
 
@@ -83,7 +83,7 @@ func dcopy(srcdir, destdir string, info os.FileInfo, opt Options) (err error) {
 		return err
 	}
 	// Recover dir mode with original one.
-	defer chmod(destdir, originalMode, &err)
+	defer chmod(destdir, originalMode|opt.AddPermission, &err)
 
 	contents, err := ioutil.ReadDir(srcdir)
 	if err != nil {

--- a/options.go
+++ b/options.go
@@ -1,11 +1,16 @@
 package copy
 
+import "os"
+
 // Options specifies optional actions on copying.
 type Options struct {
 	// OnSymlink can specify what to do on symlink
 	OnSymlink func(p string) SymlinkAction
 	// Skip can specify which files should be skipped
 	Skip func(src string) bool
+	// AddPermission to every entities,
+	// NO MORE THAN 0777
+	AddPermission os.FileMode
 }
 
 // SymlinkAction represents what to do on symlink.
@@ -23,9 +28,10 @@ const (
 // DefaultOptions by default.
 var DefaultOptions = Options{
 	OnSymlink: func(string) SymlinkAction {
-		return Shallow
+		return Shallow // Do shallow copy
 	},
 	Skip: func(string) bool {
-		return false
+		return false // Don't skip
 	},
+	AddPermission: 0, // Add nothing
 }

--- a/testdata/case07/README.md
+++ b/testdata/case07/README.md
@@ -1,0 +1,3 @@
+# Case 07: Add Permission
+
+`Options.AddPermission` should add permission to all the dirs and files, if specified.

--- a/testdata/case07/dir_0500/README.md
+++ b/testdata/case07/dir_0500/README.md
@@ -1,0 +1,1 @@
+A file under 0500


### PR DESCRIPTION
Sometimes, we don't want to preserve the original permission of source entries. `Options.AddPermission` can add specific permission (e.g. `0200` = `--w-------`) to the original permission.

Example:


| - | - |
|:----|:-----|
| original | `dr-xr--r--` |
| options | `Options{AddPermission: 0200}` |
| results | `drwxr--r--` |
