### PR TITLE
Add option to sync file after copy

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -67,6 +67,10 @@ func fcopy(src, dest string, info os.FileInfo, opt Options) (err error) {
 	}
 	defer fclose(s, &err)
 
+	if opt.Sync {
+		defer fsync(f, &err)
+	}
+
 	_, err = io.Copy(f, s)
 	return err
 }
@@ -138,6 +142,15 @@ func lcopy(src, dest string) error {
 // BUT respecting the error already reported.
 func fclose(f *os.File, reported *error) {
 	if err := f.Close(); *reported == nil {
+		*reported = err
+	}
+}
+
+// fsync ANYHOW closes file,
+// with asiging error raised during Close,
+// BUT respecting the error already reported.
+func fsync(f *os.File, reported *error) {
+	if err := f.Sync(); *reported == nil {
 		*reported = err
 	}
 }

--- a/copy.go
+++ b/copy.go
@@ -146,8 +146,8 @@ func fclose(f *os.File, reported *error) {
 	}
 }
 
-// fsync ANYHOW closes file,
-// with asiging error raised during Close,
+// fsync ANYHOW flushes file to the disk,
+// with asiging error raised during Sync,
 // BUT respecting the error already reported.
 func fsync(f *os.File, reported *error) {
 	if err := f.Sync(); *reported == nil {

--- a/options.go
+++ b/options.go
@@ -11,7 +11,10 @@ type Options struct {
 	// AddPermission to every entities,
 	// NO MORE THAN 0777
 	AddPermission os.FileMode
-	// Sync file after copy
+	// Sync file after copy.
+	// Useful in case when file must be on the disk
+	// (in case crash happens, for example),
+	// at the expense of some performance penalty
 	Sync bool
 }
 

--- a/options.go
+++ b/options.go
@@ -11,6 +11,8 @@ type Options struct {
 	// AddPermission to every entities,
 	// NO MORE THAN 0777
 	AddPermission os.FileMode
+	// Sync file after copy
+	Sync bool
 }
 
 // SymlinkAction represents what to do on symlink.
@@ -35,6 +37,7 @@ func getDefaultOptions() Options {
 		Skip: func(string) bool {
 			return false // Don't skip
 		},
-		AddPermission: 0, // Add nothing
+		AddPermission: 0,     // Add nothing
+		Sync:          false, // Do not sync
 	}
 }


### PR DESCRIPTION
Sometimes it is necessary to sync a file after copy. For example, when writing to something like and EBS volume, then immediately taking a snapshot of that volume. Without sync, file will most likely be empty when this snapshot is attached back.
This commit adds an options to run a sync before closing destination file.