### PR TITLE
Skip by file info too

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -98,9 +98,16 @@ func dcopy(srcdir, destdir string, info os.FileInfo, opt Options) (err error) {
 		return
 	}
 
+	var skip bool
 	for _, content := range contents {
 		cs, cd := filepath.Join(srcdir, content.Name()), filepath.Join(destdir, content.Name())
-		if err = copy(cs, cd, content, opt.Skip(cs), opt); err != nil {
+
+		skip, err = opt.Skip(cs)
+		if err != nil {
+			return
+		}
+
+		if err = copy(cs, cd, content, skip, opt); err != nil {
 			// If any error, exit immediately
 			return
 		}
@@ -123,7 +130,11 @@ func onsymlink(src, dest string, info os.FileInfo, opt Options) error {
 		if err != nil {
 			return err
 		}
-		return copy(orig, dest, info, opt.Skip(orig), opt)
+		skip, err := opt.Skip(orig)
+		if err != nil {
+			return err
+		}
+		return copy(orig, dest, info, skip, opt)
 	case Skip:
 		fallthrough
 	default:

--- a/copy.go
+++ b/copy.go
@@ -20,18 +20,14 @@ func Copy(src, dest string, opt ...Options) error {
 	if err != nil {
 		return err
 	}
-	return copy(src, dest, info, assure(opt...))
+	return copyDispatcher(src, dest, info, assure(opt...)) // To ignore skip logic for root entry
 }
 
-// copy dispatches copy-funcs according to the mode.
-// Because this "copy" could be called recursively,
+// copyDispatcher dispatches copy-funcs according to the mode.
+// Because this function could be called recursively
+// (copyDispatcher -> copy-func by mode -> copy -> copyDispatcher)
 // "info" MUST be given here, NOT nil.
-func copy(src, dest string, info os.FileInfo, opt Options) error {
-
-	if opt.Skip(src) {
-		return nil
-	}
-
+func copyDispatcher(src, dest string, info os.FileInfo, opt Options) error {
 	if info.Mode()&os.ModeSymlink != 0 {
 		return onsymlink(src, dest, info, opt)
 	}
@@ -40,6 +36,15 @@ func copy(src, dest string, info os.FileInfo, opt Options) error {
 		return dcopy(src, dest, info, opt)
 	}
 	return fcopy(src, dest, info, opt)
+}
+
+// copy implements the extension of copyDispatcher function
+// by checking whether it is necessary to skip the file.
+func copy(src, dest string, info os.FileInfo, opt Options) error {
+	if opt.Skip(src, info) {
+		return nil
+	}
+	return copyDispatcher(src, dest, info, opt)
 }
 
 // fcopy is for just a file,

--- a/example_test.go
+++ b/example_test.go
@@ -24,7 +24,7 @@ func ExampleOptions() {
 		"testdata/example",
 		"testdata.copy/example_with_options",
 		Options{
-			Skip: func(src string) bool {
+			Skip: func(src string, info os.FileInfo) bool {
 				return strings.HasSuffix(src, ".git-like")
 			},
 			OnSymlink: func(src string) SymlinkAction {

--- a/example_test.go
+++ b/example_test.go
@@ -24,8 +24,8 @@ func ExampleOptions() {
 		"testdata/example",
 		"testdata.copy/example_with_options",
 		Options{
-			Skip: func(src string) bool {
-				return strings.HasSuffix(src, ".git-like")
+			Skip: func(src string) (bool, error) {
+				return strings.HasSuffix(src, ".git-like"), nil
 			},
 			OnSymlink: func(src string) SymlinkAction {
 				return Skip

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0 h1:TJIWdbX0B+kpNagQrjgq8bCMrbhiuX73M2XwgtDMoOI=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.1 h1:BCmzIS3n71sGfHB5NMNDB3lHYPz8fWSkCAErHed//qc=

--- a/options.go
+++ b/options.go
@@ -7,7 +7,7 @@ type Options struct {
 	// OnSymlink can specify what to do on symlink
 	OnSymlink func(src string) SymlinkAction
 	// Skip can specify which files should be skipped
-	Skip func(src string) bool
+	Skip func(src string) (bool, error)
 	// AddPermission to every entities,
 	// NO MORE THAN 0777
 	AddPermission os.FileMode
@@ -37,8 +37,8 @@ func getDefaultOptions() Options {
 		OnSymlink: func(string) SymlinkAction {
 			return Shallow // Do shallow copy
 		},
-		Skip: func(string) bool {
-			return false // Don't skip
+		Skip: func(string) (bool, error) {
+			return false, nil // Don't skip
 		},
 		AddPermission: 0,     // Add nothing
 		Sync:          false, // Do not sync

--- a/options.go
+++ b/options.go
@@ -7,7 +7,7 @@ type Options struct {
 	// OnSymlink can specify what to do on symlink
 	OnSymlink func(src string) SymlinkAction
 	// Skip can specify which files should be skipped
-	Skip func(src string) bool
+	Skip func(src string, info os.FileInfo) bool
 	// AddPermission to every entities,
 	// NO MORE THAN 0777
 	AddPermission os.FileMode
@@ -37,7 +37,7 @@ func getDefaultOptions() Options {
 		OnSymlink: func(string) SymlinkAction {
 			return Shallow // Do shallow copy
 		},
-		Skip: func(string) bool {
+		Skip: func(string, os.FileInfo) bool {
 			return false // Don't skip
 		},
 		AddPermission: 0,     // Add nothing


### PR DESCRIPTION
Hello!
Thank you for package. 

I faced to a problem when I need to copy all files with a specific extension, but then the Skip() function ignores directories.

Therefore, I propose such a small addition. Thank u!

P.S. Maybe you will rename a package so that it does not conflict with the standard copy function?