### PR TITLE
Fix support for symlink deep copy.

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -20,7 +20,7 @@ func TestMain(m *testing.M) {
 
 func setup(m *testing.M) {
 	os.MkdirAll("testdata.copy", os.ModePerm)
-	os.Symlink("testdata/case01", "testdata/case03/case01")
+	os.Symlink("../../testdata/case01", "testdata/case03/case01")
 	os.Chmod("testdata/case07/dir_0500", 0500)
 	os.Chmod("testdata/case07/file_0444", 0444)
 }

--- a/all_test.go
+++ b/all_test.go
@@ -23,10 +23,12 @@ func setup(m *testing.M) {
 	os.Symlink("../../testdata/case01", "testdata/case03/case01")
 	os.Chmod("testdata/case07/dir_0500", 0500)
 	os.Chmod("testdata/case07/file_0444", 0444)
+	os.Symlink("testdata/case01", "testdata/case09/case01")
 }
 
 func teardown(m *testing.M) {
 	os.RemoveAll("testdata/case03/case01")
+	os.RemoveAll("testdata/case09/case01")
 	os.RemoveAll("testdata.copy")
 }
 
@@ -219,5 +221,11 @@ func TestCopy(t *testing.T) {
 		opt := Options{Sync: true}
 		err = Copy("testdata/case08", "testdata.copy/case08", opt)
 		Expect(t, err).ToBe(nil)
+	})
+
+	When(t, "invalid symlink with Opt.OnSymlink == Deep", func(t *testing.T) {
+		opt := Options{OnSymlink: func(string) SymlinkAction { return Deep }}
+		err := Copy("testdata/case09", "testdata.copy/case09.deep", opt)
+		Expect(t, os.IsNotExist(err)).ToBe(true)
 	})
 }

--- a/copy.go
+++ b/copy.go
@@ -123,7 +123,7 @@ func onsymlink(src, dest string, info os.FileInfo, opt Options) error {
 	case Shallow:
 		return lcopy(src, dest)
 	case Deep:
-		orig, err := os.Readlink(src)
+		orig, err := filepath.EvalSymlinks(src)
 		if err != nil {
 			return err
 		}

--- a/testdata/case09/README.md
+++ b/testdata/case09/README.md
@@ -1,0 +1,2 @@
+Catch invalid symlinks.
+See https://github.com/otiai10/copy/pull/27 for more information.


### PR DESCRIPTION
The test was covering `SymlinkAction==Deep`. However, the setup was using:
```
os.Symlink("testdata/case01", "testdata/case03/case01")
```
That creates a symlink to `testdata/case03/testdata/case01`, which does
not exists. Because the code was using only `os.Readlink`, the test
was passing blissfully.

Instead:
 - Use `filepath.EvalSymlinks` to resolve the path completely.
 - Use a relative link in the test.