### PR TITLE
Fix small bug in lcopy and test setup

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -38,10 +38,10 @@ func setup(m *testing.M) error {
 	if err := os.Chmod("testdata/case07/file_0444", 0444); err != nil {
 		return err
 	}
-  
-  if err := os.Symlink("testdata/case01", "testdata/case09/case01"); err != nil {
-    return err
-  }
+
+	if err := os.Symlink("testdata/case01", "testdata/case09/case01"); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -98,6 +98,11 @@ func TestCopy(t *testing.T) {
 		info, err := os.Lstat("testdata.copy/case03/case01")
 		Expect(t, err).ToBe(nil)
 		Expect(t, info.Mode()&os.ModeSymlink).Not().ToBe(0)
+	})
+
+	When(t, "copying symbolic link to a directory that doesn't exist yet", func(t *testing.T) {
+		err = Copy("testdata/case03/case01", "testdata.copy/case03/case01.2")
+		Expect(t, err).ToBe(nil)
 	})
 
 	When(t, "symlink with Opt.OnSymlink provided", func(t *testing.T) {

--- a/all_test.go
+++ b/all_test.go
@@ -13,11 +13,13 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	var code int
 	if err := setup(m); err != nil {
-		teardown(m)
-		log.Fatalf("failed setup: %v", err)
+		log.Printf("failed setup: %v", err)
+		code = 1
+	} else {
+		code = m.Run()
 	}
-	code := m.Run()
 	teardown(m)
 	os.Exit(code)
 }
@@ -98,11 +100,6 @@ func TestCopy(t *testing.T) {
 		info, err := os.Lstat("testdata.copy/case03/case01")
 		Expect(t, err).ToBe(nil)
 		Expect(t, info.Mode()&os.ModeSymlink).Not().ToBe(0)
-	})
-
-	When(t, "copying symbolic link to a directory that doesn't exist yet", func(t *testing.T) {
-		err = Copy("testdata/case03/case01", "testdata.copy/case03/case01.2")
-		Expect(t, err).ToBe(nil)
 	})
 
 	When(t, "copying symbolic link to not permitted location", func(t *testing.T) {
@@ -258,5 +255,10 @@ func TestCopy(t *testing.T) {
 		opt := Options{OnSymlink: func(string) SymlinkAction { return Deep }}
 		err := Copy("testdata/case09", "testdata.copy/case09.deep", opt)
 		Expect(t, os.IsNotExist(err)).ToBe(true)
+	})
+
+	When(t, "copying symbolic link where intermediate directories don't exist yet", func(t *testing.T) {
+		err = Copy("testdata/case03/case01", "testdata.copy/case10/case10.1/destination")
+		Expect(t, err).ToBe(nil)
 	})
 }

--- a/all_test.go
+++ b/all_test.go
@@ -3,6 +3,7 @@ package copy
 import (
 	"errors"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,17 +13,33 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	setup(m)
+	if err := setup(m); err != nil {
+		teardown(m)
+		log.Fatalf("failed setup: %v", err)
+	}
 	code := m.Run()
 	teardown(m)
 	os.Exit(code)
 }
 
-func setup(m *testing.M) {
-	os.MkdirAll("testdata.copy", os.ModePerm)
-	os.Symlink("testdata/case01", "testdata/case03/case01")
-	os.Chmod("testdata/case07/dir_0500", 0500)
-	os.Chmod("testdata/case07/file_0444", 0444)
+func setup(m *testing.M) error {
+	if err := os.MkdirAll("testdata.copy", os.ModePerm); err != nil {
+		return err
+	}
+
+	if err := os.Symlink("testdata/case01", "testdata/case03/case01"); err != nil {
+		return err
+	}
+
+	if err := os.Chmod("testdata/case07/dir_0500", 0500); err != nil {
+		return err
+	}
+
+	if err := os.Chmod("testdata/case07/file_0444", 0444); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func teardown(m *testing.M) {

--- a/all_test.go
+++ b/all_test.go
@@ -105,6 +105,12 @@ func TestCopy(t *testing.T) {
 		Expect(t, err).ToBe(nil)
 	})
 
+	When(t, "copying symbolic link to not permitted location", func(t *testing.T) {
+		err = Copy("testdata/case03/case01", "/case03/case01.2")
+		Expect(t, err).Not().ToBe(nil)
+		Expect(t, err).TypeOf("*os.PathError")
+	})
+
 	When(t, "symlink with Opt.OnSymlink provided", func(t *testing.T) {
 		opt := Options{OnSymlink: func(string) SymlinkAction { return Deep }}
 		err := Copy("testdata/case03", "testdata.copy/case03.deep", opt)

--- a/copy.go
+++ b/copy.go
@@ -146,6 +146,12 @@ func lcopy(src, dest string) error {
 	if err != nil {
 		return err
 	}
+
+	// Create the directories on the path to the dest symlink.
+	if err = os.MkdirAll(filepath.Dir(dest), os.ModePerm); err != nil {
+		return err
+	}
+
 	return os.Symlink(src, dest)
 }
 

--- a/copy.go
+++ b/copy.go
@@ -28,7 +28,7 @@ func Copy(src, dest string, opt ...Options) error {
 func switchboard(src, dest string, info os.FileInfo, opt Options) error {
 	switch {
 	case info.Mode()&os.ModeSymlink != 0:
-		return onsymlink(src, dest, info, opt)
+		return onsymlink(src, dest, opt)
 	case info.IsDir():
 		return dcopy(src, dest, info, opt)
 	default:
@@ -117,7 +117,7 @@ func dcopy(srcdir, destdir string, info os.FileInfo, opt Options) (err error) {
 	return
 }
 
-func onsymlink(src, dest string, info os.FileInfo, opt Options) error {
+func onsymlink(src, dest string, opt Options) error {
 
 	switch opt.OnSymlink(src) {
 	case Shallow:
@@ -127,7 +127,7 @@ func onsymlink(src, dest string, info os.FileInfo, opt Options) error {
 		if err != nil {
 			return err
 		}
-		info, err = os.Lstat(orig)
+		info, err := os.Lstat(orig)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
1. Check errors during test setup.
2. Create directories on the path to dest in `lcopy()`.