### PR TITLE
add PreserveTimes option

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -5,8 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"syscall"
-	"time"
 )
 
 const (
@@ -28,14 +26,25 @@ func Copy(src, dest string, opt ...Options) error {
 // switchboard switches proper copy functions regarding file type, etc...
 // If there would be anything else here, add a case to this switchboard.
 func switchboard(src, dest string, info os.FileInfo, opt Options) error {
+	err := error(nil)
 	switch {
 	case info.Mode()&os.ModeSymlink != 0:
-		return onsymlink(src, dest, info, opt)
+		err = onsymlink(src, dest, info, opt)
 	case info.IsDir():
-		return dcopy(src, dest, info, opt)
+		err = dcopy(src, dest, info, opt)
 	default:
-		return fcopy(src, dest, info, opt)
+		err = fcopy(src, dest, info, opt)
 	}
+
+	if err != nil {
+		return err
+	}
+
+	if opt.PreserveTimes {
+		preserveTime(info, dest)
+	}
+
+	return err
 }
 
 // copy decide if this src should be copied or not.
@@ -50,23 +59,7 @@ func copy(src, dest string, info os.FileInfo, opt Options) error {
 		return nil
 	}
 
-	err = switchboard(src, dest, info, opt)
-	if err != nil {
-		return err
-	}
-
-	if opt.PreserveTimes {
-		mtime := info.ModTime()
-		statPtr := info.Sys()
-		if statPtr == nil {
-			return err
-		}
-		stat := statPtr.(*syscall.Stat_t)
-		atime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
-		os.Chtimes(dest, atime, mtime)
-	}
-
-	return err
+	return switchboard(src, dest, info, opt)
 }
 
 // fcopy is for just a file,
@@ -137,7 +130,6 @@ func dcopy(srcdir, destdir string, info os.FileInfo, opt Options) (err error) {
 }
 
 func onsymlink(src, dest string, info os.FileInfo, opt Options) error {
-
 	switch opt.OnSymlink(src) {
 	case Shallow:
 		return lcopy(src, dest)

--- a/copy.go
+++ b/copy.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"syscall"
+	"time"
 )
 
 const (
@@ -47,7 +49,17 @@ func copy(src, dest string, info os.FileInfo, opt Options) error {
 	if skip {
 		return nil
 	}
-	return switchboard(src, dest, info, opt)
+
+	err = switchboard(src, dest, info, opt)
+
+	if opt.PreserveTimes {
+		mtime := info.ModTime()
+		stat := info.Sys().(*syscall.Stat_t)
+		atime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+		os.Chtimes(dest, atime, mtime)
+	}
+
+	return err
 }
 
 // fcopy is for just a file,

--- a/copy.go
+++ b/copy.go
@@ -51,10 +51,17 @@ func copy(src, dest string, info os.FileInfo, opt Options) error {
 	}
 
 	err = switchboard(src, dest, info, opt)
+	if err != nil {
+		return err
+	}
 
 	if opt.PreserveTimes {
 		mtime := info.ModTime()
-		stat := info.Sys().(*syscall.Stat_t)
+		statPtr := info.Sys()
+		if statPtr == nil {
+			return err
+		}
+		stat := statPtr.(*syscall.Stat_t)
 		atime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
 		os.Chtimes(dest, atime, mtime)
 	}

--- a/fix_time_unix.go
+++ b/fix_time_unix.go
@@ -1,0 +1,21 @@
+package copy
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func preserveTime(info os.FileInfo, dest string) error {
+	mtime := unix.NsecToTimeval(info.ModTime().UnixNano())
+
+	statPtr := info.Sys()
+	if statPtr == nil {
+		return fmt.Errorf("Error in obtain stat structure")
+	}
+	stat := statPtr.(*syscall.Stat_t)
+	atime := unix.NsecToTimeval(int64(stat.Atim.Sec)*1e9 + int64(stat.Atim.Nsec))
+	return unix.Lutimes(dest, []unix.Timeval{atime, mtime})
+}

--- a/fix_time_windows.go
+++ b/fix_time_windows.go
@@ -1,0 +1,22 @@
+package copy
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+func preserveTime(info os.FileInfo, dest string) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil
+	}
+	mtime := info.ModTime()
+	statPtr := info.Sys()
+	if statPtr == nil {
+		return fmt.Errorf("Error in obtain stat structure")
+	}
+	stat := statPtr.(*syscall.Stat_t)
+	atime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+	return os.Chtimes(dest, atime, mtime)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/otiai10/copy
+module github.com/siscia/copy
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
-module github.com/siscia/copy
+module github.com/otiai10/copy
 
 go 1.12
 
-require github.com/otiai10/mint v1.3.1
+require (
+	github.com/otiai10/mint v1.3.1
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
+)

--- a/go.sum
+++ b/go.sum
@@ -3,3 +3,5 @@ github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.1 h1:BCmzIS3n71sGfHB5NMNDB3lHYPz8fWSkCAErHed//qc=
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/options.go
+++ b/options.go
@@ -17,6 +17,7 @@ type Options struct {
 	// at the expense of some performance penalty
 	Sync bool
 	// Preserve the atime and the mtime of the entries
+	// On linux we can preserve only up to 1 millisecond accuracy
 	PreserveTimes bool
 }
 

--- a/options.go
+++ b/options.go
@@ -16,6 +16,8 @@ type Options struct {
 	// (in case crash happens, for example),
 	// at the expense of some performance penalty
 	Sync bool
+	// Preserve the atime and the mtime of the entries
+	PreserveTimes bool
 }
 
 // SymlinkAction represents what to do on symlink.
@@ -42,5 +44,6 @@ func getDefaultOptions() Options {
 		},
 		AddPermission: 0,     // Add nothing
 		Sync:          false, // Do not sync
+		PreserveTimes: false, // Do not preserve the modification time
 	}
 }

--- a/testdata/case09/README.md
+++ b/testdata/case09/README.md
@@ -1,0 +1,5 @@
+File with specific atime and mtime.
+
+These two properties should be preserved if we provide the PreserveTimes options to copy.Copy.
+
+The properties should be preserverd also for the directories and the links.

--- a/testdata/case09/symlink
+++ b/testdata/case09/symlink
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
The `PreserveTimes` option allows the copy to maintains the mtime and ctime of files and directory.

 