### PR TITLE
Add fileinfo to skip function

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -152,7 +152,7 @@ func TestOptions_OnSymlink(t *testing.T) {
 }
 
 func TestOptions_Skip(t *testing.T) {
-	opt := Options{Skip: func(src string) (bool, error) {
+	opt := Options{Skip: func(src string, info os.FileInfo) (bool, error) {
 		switch {
 		case strings.HasSuffix(src, "_skip"):
 			return true, nil
@@ -186,7 +186,7 @@ func TestOptions_Skip(t *testing.T) {
 
 	Because(t, "if Skip func returns error, Copy should be interrupted", func(t *testing.T) {
 		errInsideSkipFunc := errors.New("Something wrong inside Skip")
-		opt := Options{Skip: func(src string) (bool, error) {
+		opt := Options{Skip: func(src string, info os.FileInfo) (bool, error) {
 			return false, errInsideSkipFunc
 		}}
 		err := Copy("testdata/case06", "testdata.copy/case06.01", opt)

--- a/copy.go
+++ b/copy.go
@@ -60,7 +60,7 @@ func switchboard(src, dest string, info os.FileInfo, opt Options) (err error) {
 // Because this "copy" could be called recursively,
 // "info" MUST be given here, NOT nil.
 func copy(src, dest string, info os.FileInfo, opt Options) error {
-	skip, err := opt.Skip(src)
+	skip, err := opt.Skip(src, info)
 	if err != nil {
 		return err
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -24,7 +24,7 @@ func ExampleOptions() {
 		"testdata/example",
 		"testdata.copy/example_with_options",
 		Options{
-			Skip: func(src string) (bool, error) {
+			Skip: func(src string, info os.FileInfo) (bool, error) {
 				return strings.HasSuffix(src, ".git-like"), nil
 			},
 			OnSymlink: func(src string) SymlinkAction {

--- a/options.go
+++ b/options.go
@@ -12,7 +12,7 @@ type Options struct {
 	OnDirExists func(src, dest string) DirExistsAction
 
 	// Skip can specify which files should be skipped
-	Skip func(src string) (bool, error)
+	Skip func(src string, info os.FileInfo) (bool, error)
 
 	// AddPermission to every entities,
 	// NO MORE THAN 0777
@@ -66,7 +66,7 @@ func getDefaultOptions(src, dest string) Options {
 			return Shallow // Do shallow copy
 		},
 		OnDirExists: nil, // Default behavior is "Merge".
-		Skip: func(string) (bool, error) {
+		Skip: func(string, os.FileInfo) (bool, error) {
 			return false, nil // Don't skip
 		},
 		AddPermission: 0,     // Add nothing


### PR DESCRIPTION
FileInfo is needed to determine whether the file needs to be skipped in many cases.