### PR TITLE
Fix for different GOARCHs

### DIFF
--- a/stat_times.go
+++ b/stat_times.go
@@ -14,8 +14,8 @@ func getTimeSpec(info os.FileInfo) timespec {
 	stat := info.Sys().(*syscall.Stat_t)
 	times := timespec{
 		Mtime: info.ModTime(),
-		Atime: time.Unix(stat.Atim.Sec, stat.Atim.Nsec),
-		Ctime: time.Unix(stat.Ctim.Sec, stat.Ctim.Nsec),
+		Atime: time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)),
+		Ctime: time.Unix(int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec)),
 	}
 	return times
 }


### PR DESCRIPTION
I was having an issue with [probonopd/go-appimage](https;//github.com/probonopd/go-appimage) not building via TravisCI, particularly with GOARCH=386.