### PR TITLE
Fix build on Apple Silicon

### DIFF
--- a/stat_times_darwin.go
+++ b/stat_times_darwin.go
@@ -1,4 +1,4 @@
-// +build amd64,darwin
+// +build darwin
 
 package copy
 


### PR DESCRIPTION
Don't assume that Darwin is amd64-only.