### PR TITLE
PathError moved from os to fs in Go 1.16

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -57,7 +57,7 @@ func TestCopy(t *testing.T) {
 		}
 		err := Copy("test/data/case00", filepath.Join("test/data/case00", dest))
 		Expect(t, err).Not().ToBe(nil)
-		Expect(t, err).TypeOf("*os.PathError")
+		Expect(t, err).TypeOf("*fs.PathError")
 	})
 
 	When(t, "try to create not permitted location", func(t *testing.T) {
@@ -66,13 +66,13 @@ func TestCopy(t *testing.T) {
 		}
 		err := Copy("test/data/case00", "/case00")
 		Expect(t, err).Not().ToBe(nil)
-		Expect(t, err).TypeOf("*os.PathError")
+		Expect(t, err).TypeOf("*fs.PathError")
 	})
 
 	When(t, "try to create a directory on existing file name", func(t *testing.T) {
 		err := Copy("test/data/case02", "test/data.copy/case00/README.md")
 		Expect(t, err).Not().ToBe(nil)
-		Expect(t, err).TypeOf("*os.PathError")
+		Expect(t, err).TypeOf("*fs.PathError")
 	})
 
 	When(t, "source directory includes symbolic link", func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>

See https://github.com/golang/go/commit/d4da735091986868015369e01c63794af9cc9b84

I don't expect you to merge as is as it would break < 1.16, this is the patch I used to make it work in Fedosa Rawhide with Go 1.16 beta 1.