### PR TITLE
Add support for named pipes

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"syscall"
 
 	. "github.com/otiai10/mint"
 )
@@ -22,6 +23,7 @@ func setup(m *testing.M) {
 	os.Symlink("test/data/case01", "test/data/case03/case01")
 	os.Chmod("test/data/case07/dir_0555", 0555)
 	os.Chmod("test/data/case07/file_0444", 0444)
+	syscall.Mkfifo("test/data/case11/foo/bar", 0555)
 }
 
 func teardown(m *testing.M) {
@@ -87,6 +89,27 @@ func TestCopy(t *testing.T) {
 		Expect(t, err).ToBe(nil)
 	})
 
+	When(t, "specified src contains a folder with a named pipe", func(t *testing.T) {
+		dest:= "test/data.copy/case11"
+		err := Copy("test/data/case11", dest)
+		Expect(t, err).ToBe(nil)
+
+		info, err := os.Lstat("test/data/case11/foo/bar")
+		Expect(t, err).ToBe(nil)
+		Expect(t, info.Mode()&os.ModeNamedPipe != 0).ToBe(true)
+		Expect(t, info.Mode().Perm()).ToBe(os.FileMode(0555))
+	})
+
+	When(t, "specified src is a named pipe", func(t *testing.T) {
+		dest:= "test/data.copy/case11/foo/bar.named"
+		err := Copy("test/data/case11/foo/bar", dest)
+		Expect(t, err).ToBe(nil)
+
+		info, err := os.Lstat(dest)
+		Expect(t, err).ToBe(nil)
+		Expect(t, info.Mode()&os.ModeNamedPipe != 0).ToBe(true)
+		Expect(t, info.Mode().Perm()).ToBe(os.FileMode(0555))
+	})
 }
 
 func TestOptions_OnSymlink(t *testing.T) {

--- a/all_test.go
+++ b/all_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"syscall"
 
 	. "github.com/otiai10/mint"
 )
@@ -16,14 +15,6 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	teardown(m)
 	os.Exit(code)
-}
-
-func setup(m *testing.M) {
-	os.MkdirAll("test/data.copy", os.ModePerm)
-	os.Symlink("test/data/case01", "test/data/case03/case01")
-	os.Chmod("test/data/case07/dir_0555", 0555)
-	os.Chmod("test/data/case07/file_0444", 0444)
-	syscall.Mkfifo("test/data/case11/foo/bar", 0555)
 }
 
 func teardown(m *testing.M) {
@@ -89,27 +80,7 @@ func TestCopy(t *testing.T) {
 		Expect(t, err).ToBe(nil)
 	})
 
-	When(t, "specified src contains a folder with a named pipe", func(t *testing.T) {
-		dest:= "test/data.copy/case11"
-		err := Copy("test/data/case11", dest)
-		Expect(t, err).ToBe(nil)
-
-		info, err := os.Lstat("test/data/case11/foo/bar")
-		Expect(t, err).ToBe(nil)
-		Expect(t, info.Mode()&os.ModeNamedPipe != 0).ToBe(true)
-		Expect(t, info.Mode().Perm()).ToBe(os.FileMode(0555))
-	})
-
-	When(t, "specified src is a named pipe", func(t *testing.T) {
-		dest:= "test/data.copy/case11/foo/bar.named"
-		err := Copy("test/data/case11/foo/bar", dest)
-		Expect(t, err).ToBe(nil)
-
-		info, err := os.Lstat(dest)
-		Expect(t, err).ToBe(nil)
-		Expect(t, info.Mode()&os.ModeNamedPipe != 0).ToBe(true)
-		Expect(t, info.Mode().Perm()).ToBe(os.FileMode(0555))
-	})
+	testPipes(t)
 }
 
 func TestOptions_OnSymlink(t *testing.T) {

--- a/all_test_others.go
+++ b/all_test_others.go
@@ -1,0 +1,43 @@
+// +build !windows
+
+package copy
+
+import (
+	"os"
+	"testing"
+	"syscall"
+
+	. "github.com/otiai10/mint"
+)
+
+func setup(m *testing.M) {
+	os.MkdirAll("test/data.copy", os.ModePerm)
+	os.Symlink("test/data/case01", "test/data/case03/case01")
+	os.Chmod("test/data/case07/dir_0555", 0555)
+	os.Chmod("test/data/case07/file_0444", 0444)
+	syscall.Mkfifo("test/data/case11/foo/bar", 0555)
+}
+
+func testPipes(t *testing.T) {
+	When(t, "specified src contains a folder with a named pipe", func(t *testing.T) {
+		dest:= "test/data.copy/case11"
+		err := Copy("test/data/case11", dest)
+		Expect(t, err).ToBe(nil)
+
+		info, err := os.Lstat("test/data/case11/foo/bar")
+		Expect(t, err).ToBe(nil)
+		Expect(t, info.Mode()&os.ModeNamedPipe != 0).ToBe(true)
+		Expect(t, info.Mode().Perm()).ToBe(os.FileMode(0555))
+	})
+
+	When(t, "specified src is a named pipe", func(t *testing.T) {
+		dest:= "test/data.copy/case11/foo/bar.named"
+		err := Copy("test/data/case11/foo/bar", dest)
+		Expect(t, err).ToBe(nil)
+
+		info, err := os.Lstat(dest)
+		Expect(t, err).ToBe(nil)
+		Expect(t, info.Mode()&os.ModeNamedPipe != 0).ToBe(true)
+		Expect(t, info.Mode().Perm()).ToBe(os.FileMode(0555))
+	})
+}

--- a/all_test_windows.go
+++ b/all_test_windows.go
@@ -1,0 +1,17 @@
+// +build windows
+
+package copy
+
+import (
+	"os"
+	"testing"
+)
+
+func setup(m *testing.M) {
+	os.MkdirAll("test/data.copy", os.ModePerm)
+	os.Symlink("test/data/case01", "test/data/case03/case01")
+	os.Chmod("test/data/case07/dir_0555", 0555)
+	os.Chmod("test/data/case07/file_0444", 0444)
+}
+
+func testPipes(t *testing.T) { }

--- a/copy.go
+++ b/copy.go
@@ -38,6 +38,8 @@ func switchboard(src, dest string, info os.FileInfo, opt Options) (err error) {
 		err = onsymlink(src, dest, info, opt)
 	case info.IsDir():
 		err = dcopy(src, dest, info, opt)
+	case info.Mode()&os.ModeNamedPipe != 0:
+		err = pcopy(dest,info)
 	default:
 		err = fcopy(src, dest, info, opt)
 	}

--- a/copy_others.go
+++ b/copy_others.go
@@ -1,0 +1,20 @@
+// +build !windows
+
+package copy
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// pcopy is for just named pipes
+func pcopy(dest string, info os.FileInfo) (err error) {
+	if err = os.MkdirAll(filepath.Dir(dest), os.ModePerm); err != nil {
+		return
+	}
+
+	err = syscall.Mkfifo(dest, uint32(info.Mode()))
+
+	return
+}

--- a/copy_windows.go
+++ b/copy_windows.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package copy
+
+import (
+	"os"
+)
+
+// pcopy is for just named pipes. Windows doesn't support them
+func pcopy(dest string, info os.FileInfo) (err error) {
+	return
+}

--- a/test/data/case11/README.md
+++ b/test/data/case11/README.md
@@ -1,0 +1,5 @@
+# Case 11
+
+When the source contains named pipes.
+
+Note: Github doesn't support tracking named pipes, so we keep the folder for the test case itself.


### PR DESCRIPTION
This prevents to hang while trying to open the file for reading. I've kept it simple to avoid any interface change, so should be good also for `v1`

The split into `_other` files was necessary since Windows doesn't support `syscall.Mkfifo`.

Fixes #47