### PR TITLE
Fix symlinks

### DIFF
--- a/test_setup.go
+++ b/test_setup.go
@@ -3,14 +3,22 @@
 package copy
 
 import (
+	"log"
 	"os"
+	"path/filepath"
 	"syscall"
 	"testing"
 )
 
 func setup(m *testing.M) {
 	os.MkdirAll("test/data.copy", os.ModePerm)
-	os.Symlink("test/data/case01", "test/data/case03/case01")
+	os.Symlink("../case01", "test/data/case03/relative")
+	os.Symlink("../case03", "test/data/case03/relative")
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("failed to get cwd: %v", err)
+	}
+	os.Symlink(filepath.Join(cwd, "test/data/case01"), "test/data/case03/absolute")
 	os.Chmod("test/data/case07/dir_0555", 0555)
 	os.Chmod("test/data/case07/file_0444", 0444)
 	syscall.Mkfifo("test/data/case11/foo/bar", 0555)


### PR DESCRIPTION
Fixes #32 

- Deep symlinks will properly be resolved with `filepath.EvalSymlinks`
- Shallow relative symlinks will error if they are broken because the destination is no longer valid relative. This can happen if the copy operation doesn't include the symlink target.
- Shallow absolute symlinks will continue to point to their original destination.