### PR TITLE
Allow buffered copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ test/data.copy
 coverage.txt
 vendor
 .vagrant
+.idea/

--- a/all_test.go
+++ b/all_test.go
@@ -25,7 +25,6 @@ func teardown(m *testing.M) {
 }
 
 func TestCopy(t *testing.T) {
-
 	err := Copy("./test/data/case00", "./test/data.copy/case00")
 	Expect(t, err).ToBe(nil)
 	info, err := os.Stat("./test/data.copy/case00/README.md")
@@ -40,6 +39,9 @@ func TestCopy(t *testing.T) {
 	When(t, "specified src is just a file", func(t *testing.T) {
 		err := Copy("test/data/case01/README.md", "test/data.copy/case01/README.md")
 		Expect(t, err).ToBe(nil)
+		content, err := ioutil.ReadFile("test/data.copy/case01/README.md")
+		Expect(t, err).ToBe(nil)
+		Expect(t, string(content)).ToBe("case01 - README.md")
 	})
 
 	When(t, "source directory includes symbolic link", func(t *testing.T) {
@@ -297,4 +299,17 @@ func TestOptions_OnDirExists(t *testing.T) {
 		err = Copy("test/data/case10/src", "test/data.copy/case10/dest.3", opt)
 		Expect(t, err).ToBe(nil)
 	})
+}
+
+func TestOptions_CopyBufferSize(t *testing.T) {
+	opt := Options{
+		CopyBufferSize: 512,
+	}
+
+	err := Copy("test/data/case12", "test/data.copy/case12", opt)
+	Expect(t, err).ToBe(nil)
+
+	content, err := ioutil.ReadFile("test/data.copy/case12/README.md")
+	Expect(t, err).ToBe(nil)
+	Expect(t, string(content)).ToBe("case12 - README.md")
 }

--- a/copy.go
+++ b/copy.go
@@ -13,12 +13,18 @@ const (
 	// so that stuff can be copied recursively even if any original directory is NOT writable.
 	// See https://github.com/otiai10/copy/pull/9 for more information.
 	tmpPermissionForDirectory = os.FileMode(0755)
+
+	defaultCopyBufferSize = 32 * 1024
 )
 
 type timespec struct {
 	Mtime time.Time
 	Atime time.Time
 	Ctime time.Time
+}
+
+type onlyWriter struct {
+	io.Writer
 }
 
 // Copy copies src to dest, doesn't matter if src is a directory or a file.
@@ -87,7 +93,9 @@ func fcopy(src, dest string, info os.FileInfo, opt Options) (err error) {
 	}
 	defer fclose(s, &err)
 
-	if _, err = io.Copy(f, s); err != nil {
+	buf := make([]byte, opt.CopyBufferSize)
+	_, err = io.CopyBuffer(onlyWriter{f}, s, buf)
+	if err != nil {
 		return
 	}
 
@@ -212,6 +220,9 @@ func assure(src, dest string, opts ...Options) Options {
 	}
 	if opts[0].Skip == nil {
 		opts[0].Skip = defopt.Skip
+	}
+	if opts[0].CopyBufferSize <= 0 {
+		opts[0].CopyBufferSize = defaultCopyBufferSize
 	}
 	opts[0].intent.src = defopt.intent.src
 	opts[0].intent.dest = defopt.intent.dest

--- a/options.go
+++ b/options.go
@@ -28,6 +28,10 @@ type Options struct {
 	// On linux we can preserve only up to 1 millisecond accuracy.
 	PreserveTimes bool
 
+	// The byte size of the buffer to use for copying files.
+	// If zero or less, the internal default buffer of 32KB is used (see io.CopyBuffer )
+	CopyBufferSize int
+
 	intent struct {
 		src  string
 		dest string
@@ -72,6 +76,7 @@ func getDefaultOptions(src, dest string) Options {
 		AddPermission: 0,     // Add nothing
 		Sync:          false, // Do not sync
 		PreserveTimes: false, // Do not preserve the modification time
+		CopyBufferSize: defaultCopyBufferSize,
 		intent: struct {
 			src  string
 			dest string

--- a/test/data/case01/README.md
+++ b/test/data/case01/README.md
@@ -1,0 +1,1 @@
+case01 - README.md

--- a/test/data/case12/README.md
+++ b/test/data/case12/README.md
@@ -1,0 +1,1 @@
+case12 - README.md


### PR DESCRIPTION
Add an option to define a buffer size when it comes to copying files.