### PR TITLE
Fix build in some OSes

### DIFF
--- a/copy_namedpipes.go
+++ b/copy_namedpipes.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!plan9,!netbsd,!aix,!illumos,!solaris
 
 package copy
 

--- a/copy_namedpipes_x.go
+++ b/copy_namedpipes_x.go
@@ -1,10 +1,12 @@
-// +build windows
+// +build windows plan9 netbsd aix illumos solaris
 
 package copy
 
 import (
 	"os"
 )
+
+// TODO: check plan9 netbsd aix illumos solaris in future
 
 // pcopy is for just named pipes. Windows doesn't support them
 func pcopy(dest string, info os.FileInfo) error {

--- a/stat_times.go
+++ b/stat_times.go
@@ -1,4 +1,4 @@
-// +build !windows,!darwin,!freebsd
+// +build !windows,!darwin,!freebsd,!plan9,!netbsd
 
 // TODO: add more runtimes
 

--- a/stat_times_x.go
+++ b/stat_times_x.go
@@ -1,0 +1,17 @@
+// +build plan9 netbsd
+
+package copy
+
+import (
+	"os"
+)
+
+// TODO: check plan9 netbsd in future
+func getTimeSpec(info os.FileInfo) timespec {
+	times := timespec{
+		Mtime: info.ModTime(),
+		Atime: info.ModTime(),
+		Ctime: info.ModTime(),
+	}
+	return times
+}

--- a/test_setup.go
+++ b/test_setup.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!plan9,!netbsd,!aix,!illumos,!solaris
 
 package copy
 

--- a/test_setup_x.go
+++ b/test_setup_x.go
@@ -1,4 +1,4 @@
-// +build windows
+// +build windows plan9 netbsd aix illumos solaris
 
 package copy
 


### PR DESCRIPTION
After  Preserved Time feature, is not possible build programs using this package in Plan9, NetBSD, AIX, Illumos and Solaris.

This change add build constrains to solved that and maintain the main feature: copy a directory.