### PR TITLE
Make temporary permission changes of destination directory optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ type Options struct {
 	// at the expense of some performance penalty
 	Sync bool
 
+	// Prevent the copy operation making temporary changes to the permissions on the destination directory.
+	// Temporary changes are made to ensure that files can be copied even if the source directory is not writeable.
+	// You will want to enable this option if the target directory is not owned by the copy process.
+	NoTemporaryPermChanges bool
+
 	// Preserve the atime and the mtime of the entries
 	// On linux we can preserve only up to 1 millisecond accuracy
 	PreserveTimes bool

--- a/all_test.go
+++ b/all_test.go
@@ -217,6 +217,14 @@ func TestOptions_AddPermission(t *testing.T) {
 	Expect(t, info.Mode()).ToBe(os.FileMode(0444 | 0222))
 }
 
+func TestOptions_NoTemporaryPermChanges(t *testing.T) {
+	opt := Options{
+		NoTemporaryPermChanges: true,
+	}
+	err := Copy("test/data/case14", "test/owned-by-root", opt)
+	Expect(t, err).ToBe(nil)
+}
+
 func TestOptions_Sync(t *testing.T) {
 	// With Sync option, each file will be flushed to storage on copying.
 	// TODO: Since it's a bit hard to simulate real usecases here. This testcase is nonsense.

--- a/copy.go
+++ b/copy.go
@@ -137,14 +137,16 @@ func dcopy(srcdir, destdir string, info os.FileInfo, opt Options) (err error) {
 		return err // Unwelcome error type...!
 	}
 
-	originalMode := info.Mode()
+	if !opt.NoTemporaryPermChanges {
+		originalMode := info.Mode()
 
-	// Make dest dir with 0755 so that everything writable.
-	if err = os.MkdirAll(destdir, tmpPermissionForDirectory); err != nil {
-		return
+		// Make dest dir with 0755 so that everything writable.
+		if err = os.MkdirAll(destdir, tmpPermissionForDirectory); err != nil {
+			return
+		}
+		// Recover dir mode with original one.
+		defer chmod(destdir, originalMode|opt.AddPermission, &err)
 	}
-	// Recover dir mode with original one.
-	defer chmod(destdir, originalMode|opt.AddPermission, &err)
 
 	contents, err := ioutil.ReadDir(srcdir)
 	if err != nil {

--- a/options.go
+++ b/options.go
@@ -24,6 +24,11 @@ type Options struct {
 	// at the expense of some performance penalty
 	Sync bool
 
+	// Prevent the copy operation making temporary changes to the permissions on the destination directory.
+	// Temporary changes are made to ensure that files can be copied even if the source directory is not writeable.
+	// You will want to enable this option if the target directory is not owned by the copy process.
+	NoTemporaryPermChanges bool
+
 	// Preserve the atime and the mtime of the entries.
 	// On linux we can preserve only up to 1 millisecond accuracy.
 	PreserveTimes bool

--- a/test/data/case14/README.md
+++ b/test/data/case14/README.md
@@ -1,0 +1,7 @@
+# Case 14
+
+The destination folder is not owned by the process running the `Copy` operation, but is writeable by that process.
+
+In this case, the Copy operation requires the `NoTemporaryPermChanges` option to be set, otherwise a `chmod` operation is attempted on the destination dir, which will fail.
+
+See https://github.com/otiai10/copy/pull/69.

--- a/test/images/alpine.Dockerfile
+++ b/test/images/alpine.Dockerfile
@@ -10,6 +10,11 @@ RUN apk add \
 
 RUN adduser -g "" -D someuser
 
+# root-owned directory setup for test case 14
+RUN mkdir -p test/owned-by-root \
+  && chown :someuser test/owned-by-root \
+  && chmod 775 test/owned-by-root
+
 USER someuser
 
 COPY --chown=someuser:someuser . .

--- a/test/images/alpine.Dockerfile
+++ b/test/images/alpine.Dockerfile
@@ -1,14 +1,17 @@
 FROM alpine:3.14
 
+WORKDIR /app
+
 RUN apk update
 RUN apk add \
   g++ \
   git \
   go
 
-ENV GOPATH=${HOME}/go
-ENV GO111MODULE=on
-ADD . ${GOPATH}/src/github.com/otiai10/copy
-WORKDIR ${GOPATH}/src/github.com/otiai10/copy
+RUN adduser -g "" -D someuser
+
+USER someuser
+
+COPY --chown=someuser:someuser . .
 
 CMD ["go", "test", "-v", "-cover", "./..."]

--- a/test/images/archlinux.Dockerfile
+++ b/test/images/archlinux.Dockerfile
@@ -1,14 +1,17 @@
 FROM archlinux:base-20201220.0.11678
 
+WORKDIR /app
+
 RUN pacman -Sy -q --noconfirm \
   glibc \
   git \
   gcc \
   go
 
-ENV GOPATH=${HOME}/go
-ENV GO111MODULE=on
-ADD . ${GOPATH}/src/github.com/otiai10/copy
-WORKDIR ${GOPATH}/src/github.com/otiai10/copy
+RUN useradd -m someuser
+
+USER someuser
+
+COPY --chown=someuser:someuser . .
 
 CMD ["go", "test", "-v", "-cover", "./..."]

--- a/test/images/archlinux.Dockerfile
+++ b/test/images/archlinux.Dockerfile
@@ -10,6 +10,11 @@ RUN pacman -Sy -q --noconfirm \
 
 RUN useradd -m someuser
 
+# root-owned directory setup for test case 14
+RUN mkdir -p test/owned-by-root \
+  && chown :someuser test/owned-by-root \
+  && chmod 775 test/owned-by-root
+
 USER someuser
 
 COPY --chown=someuser:someuser . .

--- a/test/images/centos.Dockerfile
+++ b/test/images/centos.Dockerfile
@@ -1,13 +1,16 @@
 FROM centos:centos8
 
+WORKDIR /app
+
 RUN yum update -y -q \
     && yum install -y --quiet \
       git \
       go
 
-ENV GOPATH=${HOME}/go
-ENV GO111MODULE=on
-ADD . ${GOPATH}/src/github.com/otiai10/copy
-WORKDIR ${GOPATH}/src/github.com/otiai10/copy
+RUN useradd -m someuser
+
+USER someuser
+
+COPY --chown=someuser:someuser . .
 
 CMD ["go", "test", "-v", "-cover", "./..."]

--- a/test/images/centos.Dockerfile
+++ b/test/images/centos.Dockerfile
@@ -9,6 +9,11 @@ RUN yum update -y -q \
 
 RUN useradd -m someuser
 
+# root-owned directory setup for test case 14
+RUN mkdir -p test/owned-by-root \
+  && chown :someuser test/owned-by-root \
+  && chmod 775 test/owned-by-root
+
 USER someuser
 
 COPY --chown=someuser:someuser . .


### PR DESCRIPTION
As of https://github.com/otiai10/copy/pull/9 the `Copy` operation makes temporary changes to the permissions on the destination directory to allow for the case when the source directory is not writeable.

This behaviour is undesirable in the case where the destination directory is not owned by the process running the `Copy` - in that case the `chmod` operation will fail causing the copy to abort. This can happen in Kubernetes when mounting a volume into a container; the mount point will usually be owned by `root`. Using such a directory as the destination for a `Copy` is currently not possible using this module if the copying process is not also running as `root`.

This PR adds a new option, `NoTemporaryPermChanges`, to skip the temporary modification of permissions on the target directory.