### PR TITLE
Make package work with WASM and GopherJS targets

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -74,21 +74,20 @@ func TestCopy(t *testing.T) {
 	When(t, "try to copy a directory that has no write permission and copy file inside along with it", func(t *testing.T) {
 		src := "test/data/case05"
 		dest := "test/data.copy/case05"
-		err := os.Chmod(src, os.FileMode(0555))
+		err := os.Chmod(src, os.FileMode(0o555))
 		Expect(t, err).ToBe(nil)
 		err = Copy(src, dest)
 		Expect(t, err).ToBe(nil)
 		info, err := os.Lstat(dest)
 		Expect(t, err).ToBe(nil)
-		Expect(t, info.Mode().Perm()).ToBe(os.FileMode(0555))
-		err = os.Chmod(dest, 0755)
+		Expect(t, info.Mode().Perm()).ToBe(os.FileMode(0o555))
+		err = os.Chmod(dest, 0o755)
 		Expect(t, err).ToBe(nil)
 	})
 }
 
 func TestCopy_NamedPipe(t *testing.T) {
-
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" || runtime.GOOS == "js" {
 		t.Skip("See https://github.com/otiai10/copy/issues/47")
 	}
 
@@ -100,7 +99,7 @@ func TestCopy_NamedPipe(t *testing.T) {
 		info, err := os.Lstat("test/data/case11/foo/bar")
 		Expect(t, err).ToBe(nil)
 		Expect(t, info.Mode()&os.ModeNamedPipe != 0).ToBe(true)
-		Expect(t, info.Mode().Perm()).ToBe(os.FileMode(0555))
+		Expect(t, info.Mode().Perm()).ToBe(os.FileMode(0o555))
 	})
 
 	When(t, "specified src is a named pipe", func(t *testing.T) {
@@ -111,9 +110,8 @@ func TestCopy_NamedPipe(t *testing.T) {
 		info, err := os.Lstat(dest)
 		Expect(t, err).ToBe(nil)
 		Expect(t, info.Mode()&os.ModeNamedPipe != 0).ToBe(true)
-		Expect(t, info.Mode().Perm()).ToBe(os.FileMode(0555))
+		Expect(t, info.Mode().Perm()).ToBe(os.FileMode(0o555))
 	})
-
 }
 
 func TestOptions_OnSymlink(t *testing.T) {
@@ -200,23 +198,23 @@ func TestOptions_Skip(t *testing.T) {
 func TestOptions_PermissionControl(t *testing.T) {
 	info, err := os.Stat("test/data/case07/dir_0555")
 	Expect(t, err).ToBe(nil)
-	Expect(t, info.Mode()).ToBe(os.FileMode(0555) | os.ModeDir)
+	Expect(t, info.Mode()).ToBe(os.FileMode(0o555) | os.ModeDir)
 
 	info, err = os.Stat("test/data/case07/file_0444")
 	Expect(t, err).ToBe(nil)
-	Expect(t, info.Mode()).ToBe(os.FileMode(0444))
+	Expect(t, info.Mode()).ToBe(os.FileMode(0o444))
 
-	opt := Options{PermissionControl: AddPermission(0222)}
+	opt := Options{PermissionControl: AddPermission(0o222)}
 	err = Copy("test/data/case07", "test/data.copy/case07", opt)
 	Expect(t, err).ToBe(nil)
 
 	info, err = os.Stat("test/data.copy/case07/dir_0555")
 	Expect(t, err).ToBe(nil)
-	Expect(t, info.Mode()).ToBe(os.FileMode(0555|0222) | os.ModeDir)
+	Expect(t, info.Mode()).ToBe(os.FileMode(0o555|0o222) | os.ModeDir)
 
 	info, err = os.Stat("test/data.copy/case07/file_0444")
 	Expect(t, err).ToBe(nil)
-	Expect(t, info.Mode()).ToBe(os.FileMode(0444 | 0222))
+	Expect(t, info.Mode()).ToBe(os.FileMode(0o444 | 0o222))
 
 	When(t, "try to copy a dir owned by other users", func(t *testing.T) {
 		err := Copy("test/data/case14", "test/owned-by-root", Options{

--- a/copy_namedpipes.go
+++ b/copy_namedpipes.go
@@ -1,4 +1,5 @@
-// +build !windows,!plan9,!netbsd,!aix,!illumos,!solaris
+//go:build !windows && !plan9 && !netbsd && !aix && !illumos && !solaris && !js
+// +build !windows,!plan9,!netbsd,!aix,!illumos,!solaris,!js
 
 package copy
 

--- a/copy_namedpipes_x.go
+++ b/copy_namedpipes_x.go
@@ -1,4 +1,5 @@
-// +build windows plan9 netbsd aix illumos solaris
+//go:build windows || plan9 || netbsd || aix || illumos || solaris || js
+// +build windows plan9 netbsd aix illumos solaris js
 
 package copy
 

--- a/stat_times.go
+++ b/stat_times.go
@@ -1,4 +1,5 @@
-// +build !windows,!darwin,!freebsd,!plan9,!netbsd
+//go:build !windows && !darwin && !freebsd && !plan9 && !netbsd && !js
+// +build !windows,!darwin,!freebsd,!plan9,!netbsd,!js
 
 // TODO: add more runtimes
 

--- a/stat_times_js.go
+++ b/stat_times_js.go
@@ -1,0 +1,20 @@
+//go:build js
+// +build js
+
+package copy
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func getTimeSpec(info os.FileInfo) timespec {
+	stat := info.Sys().(*syscall.Stat_t)
+	times := timespec{
+		Mtime: info.ModTime(),
+		Atime: time.Unix(int64(stat.Atime), int64(stat.AtimeNsec)),
+		Ctime: time.Unix(int64(stat.Ctime), int64(stat.CtimeNsec)),
+	}
+	return times
+}

--- a/test_setup.go
+++ b/test_setup.go
@@ -1,4 +1,5 @@
-// +build !windows,!plan9,!netbsd,!aix,!illumos,!solaris
+//go:build !windows && !plan9 && !netbsd && !aix && !illumos && !solaris && !js
+// +build !windows,!plan9,!netbsd,!aix,!illumos,!solaris,!js
 
 package copy
 
@@ -11,7 +12,7 @@ import (
 func setup(m *testing.M) {
 	os.MkdirAll("test/data.copy", os.ModePerm)
 	os.Symlink("test/data/case01", "test/data/case03/case01")
-	os.Chmod("test/data/case07/dir_0555", 0555)
-	os.Chmod("test/data/case07/file_0444", 0444)
-	syscall.Mkfifo("test/data/case11/foo/bar", 0555)
+	os.Chmod("test/data/case07/dir_0555", 0o555)
+	os.Chmod("test/data/case07/file_0444", 0o444)
+	syscall.Mkfifo("test/data/case11/foo/bar", 0o555)
 }

--- a/test_setup_x.go
+++ b/test_setup_x.go
@@ -1,4 +1,5 @@
-// +build windows plan9 netbsd aix illumos solaris
+//go:build windows || plan9 || netbsd || aix || illumos || solaris || js
+// +build windows plan9 netbsd aix illumos solaris js
 
 package copy
 


### PR DESCRIPTION
At present, this package does not work with WASM or GopherJS compile targets. See for example, the output from `go test` for WASM:

```
$ GOOS=js GOARCH=wasm go test ./... -exec=$(go env GOROOT)/misc/wasm/go_js_wasm_exec
# github.com/otiai10/copy [github.com/otiai10/copy.test]
./copy_namedpipes.go:16:9: undefined: syscall.Mkfifo
./stat_times.go:17:30: stat.Atim undefined (type *syscall.Stat_t has no field or method Atim)
./stat_times.go:18:30: stat.Ctim undefined (type *syscall.Stat_t has no field or method Ctim)
./test_setup.go:16:2: undefined: syscall.Mkfifo
FAIL    github.com/otiai10/copy [build failed]
FAIL
```

and GopherJS:

```
$ gopherjs test ./...
test_setup.go:16:10: Mkfifo not declared by package syscall
stat_times.go:17:31: stat.Atim undefined (type *syscall.Stat_t has no field or method Atim)
stat_times.go:17:53: stat.Atim undefined (type *syscall.Stat_t has no field or method Atim)
stat_times.go:18:31: stat.Ctim undefined (type *syscall.Stat_t has no field or method Ctim)
stat_times.go:18:53: stat.Ctim undefined (type *syscall.Stat_t has no field or method Ctim)
copy_namedpipes.go:16:17: Mkfifo not declared by package syscall
```

This PR solves this problem, by using the same fallback used for Windows, which doesn't support Mkfifo, and by using the JS-specific struct field names for Atime/Ctime fields in the `syscall` package.