### PR TITLE
Support PreserveTimes for symlinks on Unix

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -249,6 +249,15 @@ func TestOptions_PreserveTimes(t *testing.T) {
 		Expect(t, plain.ModTime().Unix()).Not().ToBe(orig.ModTime().Unix())
 		Expect(t, preserved.ModTime().Unix()).ToBe(orig.ModTime().Unix())
 	}
+
+	orig, err := os.Lstat("test/data/case09/symlink")
+	Expect(t, err).ToBe(nil)
+	plain, err := os.Lstat("test/data.copy/case09/symlink")
+	Expect(t, err).ToBe(nil)
+	preserved, err := os.Lstat("test/data.copy/case09-preservetimes/symlink")
+	Expect(t, err).ToBe(nil)
+	Expect(t, plain.ModTime().Unix()).Not().ToBe(orig.ModTime().Unix())
+	Expect(t, preserved.ModTime().Unix()).ToBe(orig.ModTime().Unix())
 }
 
 func TestOptions_OnDirExists(t *testing.T) {

--- a/all_test.go
+++ b/all_test.go
@@ -249,15 +249,6 @@ func TestOptions_PreserveTimes(t *testing.T) {
 		Expect(t, plain.ModTime().Unix()).Not().ToBe(orig.ModTime().Unix())
 		Expect(t, preserved.ModTime().Unix()).ToBe(orig.ModTime().Unix())
 	}
-
-	orig, err := os.Lstat("test/data/case09/symlink")
-	Expect(t, err).ToBe(nil)
-	plain, err := os.Lstat("test/data.copy/case09/symlink")
-	Expect(t, err).ToBe(nil)
-	preserved, err := os.Lstat("test/data.copy/case09-preservetimes/symlink")
-	Expect(t, err).ToBe(nil)
-	Expect(t, plain.ModTime().Unix()).Not().ToBe(orig.ModTime().Unix())
-	Expect(t, preserved.ModTime().Unix()).ToBe(orig.ModTime().Unix())
 }
 
 func TestOptions_OnDirExists(t *testing.T) {

--- a/copy.go
+++ b/copy.go
@@ -171,7 +171,18 @@ func dcopy(srcdir, destdir string, info os.FileInfo, opt Options) (err error) {
 func onsymlink(src, dest string, opt Options) error {
 	switch opt.OnSymlink(src) {
 	case Shallow:
-		return lcopy(src, dest)
+		err := lcopy(src, dest)
+		if err != nil {
+			return err
+		}
+		if opt.PreserveTimes {
+			info, err := os.Stat(src)
+			if err != nil {
+				return err
+			}
+			return preserveLtimes(info, dest)
+		}
+		return nil
 	case Deep:
 		orig, err := os.Readlink(src)
 		if err != nil {

--- a/copy.go
+++ b/copy.go
@@ -171,8 +171,7 @@ func dcopy(srcdir, destdir string, info os.FileInfo, opt Options) (err error) {
 func onsymlink(src, dest string, opt Options) error {
 	switch opt.OnSymlink(src) {
 	case Shallow:
-		err := lcopy(src, dest)
-		if err != nil {
+		if err := lcopy(src, dest); err != nil {
 			return err
 		}
 		if opt.PreserveTimes {

--- a/copy.go
+++ b/copy.go
@@ -176,7 +176,7 @@ func onsymlink(src, dest string, opt Options) error {
 			return err
 		}
 		if opt.PreserveTimes {
-			info, err := os.Stat(src)
+			info, err := os.Lstat(src)
 			if err != nil {
 				return err
 			}

--- a/copy.go
+++ b/copy.go
@@ -176,11 +176,7 @@ func onsymlink(src, dest string, opt Options) error {
 			return err
 		}
 		if opt.PreserveTimes {
-			info, err := os.Lstat(src)
-			if err != nil {
-				return err
-			}
-			return preserveLtimes(info, dest)
+			return preserveLtimes(src, dest)
 		}
 		return nil
 	case Deep:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fako1024/copy
+module github.com/otiai10/copy
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/otiai10/copy
+module github.com/fako1024/copy
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
-module github.com/otiai10/copy
+module github.com/fako1024/copy
 
 go 1.14
 
-require github.com/otiai10/mint v1.3.3
+require (
+	github.com/otiai10/mint v1.3.3
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.3 h1:7JgpsBaN0uMkyju4tbYHu0mnM55hNKVYLsXmwr15NQI=
 github.com/otiai10/mint v1.3.3/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/preserve_ltimes.go
+++ b/preserve_ltimes.go
@@ -4,16 +4,17 @@
 package copy
 
 import (
-	"os"
-
 	"golang.org/x/sys/unix"
 )
 
-func preserveLtimes(srcinfo os.FileInfo, dest string) error {
-	spec := getTimeSpec(srcinfo)
+func preserveLtimes(src, dest string) error {
+	info := new(unix.Stat_t)
+	if err := unix.Lstat(src, info); err != nil {
+		return err
+	}
 
 	return unix.Lutimes(dest, []unix.Timeval{
-		unix.NsecToTimeval(spec.Atime.UnixNano()),
-		unix.NsecToTimeval(spec.Mtime.UnixNano()),
+		unix.NsecToTimeval(info.Atim.Nano()),
+		unix.NsecToTimeval(info.Mtim.Nano()),
 	})
 }

--- a/preserve_ltimes.go
+++ b/preserve_ltimes.go
@@ -1,0 +1,11 @@
+//go:build windows || js
+// +build windows js
+
+package copy
+
+import "os"
+
+func preserveLtimes(srcinfo os.FileInfo, dest string) error {
+	//Unsupported
+	return nil
+}

--- a/preserve_ltimes.go
+++ b/preserve_ltimes.go
@@ -1,11 +1,22 @@
-//go:build windows || js
-// +build windows js
+//go:build !windows && !plan9 && !js
+// +build !windows,!plan9,!js
 
 package copy
 
-import "os"
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
 
 func preserveLtimes(srcinfo os.FileInfo, dest string) error {
-	//Unsupported
+	spec := getTimeSpec(srcinfo)
+
+	if err := unix.Lutimes(dest, []unix.Timeval{
+		unix.NsecToTimeval(spec.Atime.UnixNano()),
+		unix.NsecToTimeval(spec.Mtime.UnixNano()),
+	}); err != nil {
+		return err
+	}
 	return nil
 }

--- a/preserve_ltimes.go
+++ b/preserve_ltimes.go
@@ -12,11 +12,8 @@ import (
 func preserveLtimes(srcinfo os.FileInfo, dest string) error {
 	spec := getTimeSpec(srcinfo)
 
-	if err := unix.Lutimes(dest, []unix.Timeval{
+	return unix.Lutimes(dest, []unix.Timeval{
 		unix.NsecToTimeval(spec.Atime.UnixNano()),
 		unix.NsecToTimeval(spec.Mtime.UnixNano()),
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }

--- a/preserve_ltimes_test.go
+++ b/preserve_ltimes_test.go
@@ -1,0 +1,28 @@
+//go:build !windows && !plan9 && !js
+// +build !windows,!plan9,!js
+
+package copy
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/otiai10/mint"
+)
+
+func TestOptions_PreserveLTimes(t *testing.T) {
+	err := Copy("test/data/case15", "test/data.copy/case15")
+	Expect(t, err).ToBe(nil)
+	opt := Options{PreserveTimes: true}
+	err = Copy("test/data/case15", "test/data.copy/case15-preserveltimes", opt)
+	Expect(t, err).ToBe(nil)
+
+	orig, err := os.Lstat("test/data/case15/symlink")
+	Expect(t, err).ToBe(nil)
+	plain, err := os.Lstat("test/data.copy/case15/symlink")
+	Expect(t, err).ToBe(nil)
+	preserved, err := os.Lstat("test/data.copy/case15-preserveltimes/symlink")
+	Expect(t, err).ToBe(nil)
+	Expect(t, plain.ModTime().Unix()).Not().ToBe(orig.ModTime().Unix())
+	Expect(t, preserved.ModTime().Unix()).ToBe(orig.ModTime().Unix())
+}

--- a/preserve_ltimes_test.go
+++ b/preserve_ltimes_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	. "github.com/otiai10/mint"
+	"golang.org/x/sys/unix"
 )
 
 func TestOptions_PreserveLTimes(t *testing.T) {
@@ -25,4 +26,10 @@ func TestOptions_PreserveLTimes(t *testing.T) {
 	Expect(t, err).ToBe(nil)
 	Expect(t, plain.ModTime().Unix()).Not().ToBe(orig.ModTime().Unix())
 	Expect(t, preserved.ModTime().Unix()).ToBe(orig.ModTime().Unix())
+}
+
+func TestOptions_PreserveLTimesErrorReturn(t *testing.T) {
+	err := preserveLtimes("doesnotexist_original.txt", "doesnotexist_copy.txt")
+	Expect(t, err).ToBe(unix.ENOENT)
+	Expect(t, os.IsNotExist(err)).ToBe(true)
 }

--- a/preserve_ltimes_x.go
+++ b/preserve_ltimes_x.go
@@ -3,8 +3,6 @@
 
 package copy
 
-import "os"
-
-func preserveLtimes(srcinfo os.FileInfo, dest string) error {
+func preserveLtimes(src, dest string) error {
 	return nil // Unsupported
 }

--- a/preserve_ltimes_x.go
+++ b/preserve_ltimes_x.go
@@ -6,6 +6,5 @@ package copy
 import "os"
 
 func preserveLtimes(srcinfo os.FileInfo, dest string) error {
-	//Unsupported
-	return nil
+	return nil // Unsupported
 }

--- a/preserve_ltimes_x.go
+++ b/preserve_ltimes_x.go
@@ -1,22 +1,11 @@
-//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+//go:build windows || js || plan9
+// +build windows js plan9
 
 package copy
 
-import (
-	"os"
-
-	"golang.org/x/sys/unix"
-)
+import "os"
 
 func preserveLtimes(srcinfo os.FileInfo, dest string) error {
-	spec := getTimeSpec(srcinfo)
-
-	if err := unix.Lutimes(dest, []unix.Timeval{
-		{Sec: spec.Atime.Unix(), Usec: spec.Atime.UnixNano() / 1000 % 1000},
-		{Sec: spec.Mtime.Unix(), Usec: spec.Mtime.UnixNano() / 1000 % 1000},
-	}); err != nil {
-		return err
-	}
+	//Unsupported
 	return nil
 }

--- a/preserve_ltimes_x.go
+++ b/preserve_ltimes_x.go
@@ -1,0 +1,22 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package copy
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func preserveLtimes(srcinfo os.FileInfo, dest string) error {
+	spec := getTimeSpec(srcinfo)
+
+	if err := unix.Lutimes(dest, []unix.Timeval{
+		{Sec: spec.Atime.Unix(), Usec: spec.Atime.UnixNano() / 1000 % 1000},
+		{Sec: spec.Mtime.Unix(), Usec: spec.Mtime.UnixNano() / 1000 % 1000},
+	}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/preserve_ltimes_x_test.go
+++ b/preserve_ltimes_x_test.go
@@ -1,0 +1,28 @@
+//go:build windows || js || plan9
+// +build windows js plan9
+
+package copy
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/otiai10/mint"
+)
+
+func TestOptions_PreserveLTimes(t *testing.T) {
+	err := Copy("test/data/case15", "test/data.copy/case15")
+	Expect(t, err).ToBe(nil)
+	opt := Options{PreserveTimes: true}
+	err = Copy("test/data/case15", "test/data.copy/case15-preserveltimes", opt)
+	Expect(t, err).ToBe(nil)
+
+	orig, err := os.Lstat("test/data/case15/symlink")
+	Expect(t, err).ToBe(nil)
+	plain, err := os.Lstat("test/data.copy/case15/symlink")
+	Expect(t, err).ToBe(nil)
+	preserved, err := os.Lstat("test/data.copy/case15-preserveltimes/symlink")
+	Expect(t, err).ToBe(nil)
+	Expect(t, plain.ModTime().Unix()).Not().ToBe(orig.ModTime().Unix())
+	Expect(t, preserved.ModTime().Unix()).Not().ToBe(orig.ModTime().Unix())
+}

--- a/test/data/case15/README.md
+++ b/test/data/case15/README.md
@@ -1,0 +1,5 @@
+File with specific atime and mtime.
+
+These two properties should be preserved if we provide the PreserveTimes options to copy.Copy.
+
+The properties should be preserverd also for the directories and the links.

--- a/test/data/case15/symlink
+++ b/test/data/case15/symlink
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
This is an addition to https://github.com/otiai10/copy/pull/31 - While symlink timestamps cannot be set universally (neither at time of link creation nor by a simple call to `os.Chtimes()`) they can be set on Unix making use of `unix.Lutimes()`. This PR extends the existing `PreserveTime` option by that, transferring the original link timestamp(s) to the newly created one if the option is set.

For unsupported architectures, a stub is provided similar to already existing ones (e.g. for ownership preservation).