### PR TITLE
Fix symlinks resolved relative to current working directory

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -205,6 +205,9 @@ func onsymlink(src, dest string, opt Options) error {
 		if err != nil {
 			return err
 		}
+		if !filepath.IsAbs(orig) {
+			orig = filepath.Join(filepath.Dir(src), orig)
+		}
 		info, err := os.Lstat(orig)
 		if err != nil {
 			return err

--- a/copy.go
+++ b/copy.go
@@ -201,12 +201,9 @@ func onsymlink(src, dest string, opt Options) error {
 		}
 		return nil
 	case Deep:
-		orig, err := os.Readlink(src)
+		orig, err := filepath.EvalSymlinks(src)
 		if err != nil {
 			return err
-		}
-		if !filepath.IsAbs(orig) {
-			orig = filepath.Join(filepath.Dir(src), orig)
 		}
 		info, err := os.Lstat(orig)
 		if err != nil {

--- a/test_setup.go
+++ b/test_setup.go
@@ -12,7 +12,7 @@ import (
 func setup(m *testing.M) {
 	os.RemoveAll("test/data.copy")
 	os.MkdirAll("test/data.copy", os.ModePerm)
-	os.Symlink("test/data/case01", "test/data/case03/case01")
+	os.Symlink("../case01", "test/data/case03/case01")
 	os.Chmod("test/data/case07/dir_0555", 0o555)
 	os.Chmod("test/data/case07/file_0444", 0o444)
 	syscall.Mkfifo("test/data/case11/foo/bar", 0o555)

--- a/test_setup_x.go
+++ b/test_setup_x.go
@@ -10,7 +10,7 @@ import (
 
 func setup(m *testing.M) {
 	os.MkdirAll("test/data.copy", os.ModePerm)
-	os.Symlink("test/data/case01", "test/data/case03/case01")
+	os.Symlink("../case01", "test/data/case03/case01")
 	os.Chmod("test/data/case07/dir_0555", 0555)
 	os.Chmod("test/data/case07/file_0444", 0444)
 }


### PR DESCRIPTION
The Deep OnSymlink option now resolves symlinks relative to the directory containing the symlink instead of the current working directory.

This is a breaking change.

Fixes #26.