### PR TITLE
Let caller hander error cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ type Options struct {
 	// OnDirExists can specify what to do when there is a directory already existing in destination.
 	OnDirExists func(src, dest string) DirExistsAction
 
+	// OnErr lets called decide whether or not to continue on particular copy error.
+	OnErr func(err error) error
+
 	// Skip can specify which files should be skipped
 	Skip func(srcinfo os.FileInfo, src, dest string) (bool, error)
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ type Options struct {
 	// OnDirExists can specify what to do when there is a directory already existing in destination.
 	OnDirExists func(src, dest string) DirExistsAction
 
-	// OnErr lets called decide whether or not to continue on particular copy error.
+	// OnError can let users decide how to handle errors (e.g., you can suppress specific error).
 	OnError func(src, dest, string, err error) error
 
 	// Skip can specify which files should be skipped

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ type Options struct {
 	OnDirExists func(src, dest string) DirExistsAction
 
 	// OnErr lets called decide whether or not to continue on particular copy error.
-	OnErr func(err error) error
+	OnError func(src, dest, string, err error) error
 
 	// Skip can specify which files should be skipped
 	Skip func(srcinfo os.FileInfo, src, dest string) (bool, error)

--- a/all_test.go
+++ b/all_test.go
@@ -378,6 +378,16 @@ func TestOptions_OnFileError(t *testing.T) {
 	_, err = os.Stat("test/data.copy/case17/non-existing")
 	Expect(t, os.IsNotExist(err)).ToBe(true)
 
+	// existing, err not passed
+	var called bool
+	opt.OnErr = func(err error) error {
+		called = true
+		return err
+	}
+	err = Copy("test/data/case17", "test/data.copy/case17", opt)
+	Expect(t, err).ToBe(nil)
+	Expect(t, called).ToBe(false)
+
 	// not existing, process err
 	opt.OnErr = func(err error) error { return err }
 	err = Copy("test/data/case17/non-existing", "test/data.copy/case17/non-existing", opt)

--- a/all_test.go
+++ b/all_test.go
@@ -364,7 +364,7 @@ func TestOptions_CopyRateLimit(t *testing.T) {
 
 func TestOptions_OnFileError(t *testing.T) {
 	opt := Options{
-		OnErr: nil,
+		OnError: nil,
 	}
 
 	// existing, process nromally
@@ -378,18 +378,15 @@ func TestOptions_OnFileError(t *testing.T) {
 	_, err = os.Stat("test/data.copy/case17/non-existing")
 	Expect(t, os.IsNotExist(err)).ToBe(true)
 
-	// existing, err not passed
-	var called bool
-	opt.OnErr = func(err error) error {
-		called = true
+	// existing, nil err not passed
+	opt.OnError = func(_, _ string, err error) error {
 		return err
 	}
 	err = Copy("test/data/case17", "test/data.copy/case17", opt)
 	Expect(t, err).ToBe(nil)
-	Expect(t, called).ToBe(false)
 
 	// not existing, process err
-	opt.OnErr = func(err error) error { return err }
+	opt.OnError = func(_, _ string, err error) error { return err }
 	err = Copy("test/data/case17/non-existing", "test/data.copy/case17/non-existing", opt)
 	Expect(t, os.IsNotExist(err)).ToBe(true)
 
@@ -397,7 +394,7 @@ func TestOptions_OnFileError(t *testing.T) {
 	Expect(t, os.IsNotExist(err)).ToBe(true)
 
 	// not existing, ignore err
-	opt.OnErr = func(err error) error { return nil }
+	opt.OnError = func(_, _ string, err error) error { return nil }
 	err = Copy("test/data/case17/non-existing", "test/data.copy/case17/non-existing", opt)
 	Expect(t, err).ToBe(nil)
 

--- a/all_test.go
+++ b/all_test.go
@@ -362,6 +362,39 @@ func TestOptions_CopyRateLimit(t *testing.T) {
 	Expect(t, elapsed > 5*time.Second).ToBe(true)
 }
 
+func TestOptions_OnFileError(t *testing.T) {
+	opt := Options{
+		OnErr: nil,
+	}
+
+	// existing, process nromally
+	err := Copy("test/data/case17", "test/data.copy/case17", opt)
+	Expect(t, err).ToBe(nil)
+
+	// not existing, process err
+	err = Copy("test/data/case17/non-existing", "test/data.copy/case17/non-existing", opt)
+	Expect(t, os.IsNotExist(err)).ToBe(true)
+
+	_, err = os.Stat("test/data.copy/case17/non-existing")
+	Expect(t, os.IsNotExist(err)).ToBe(true)
+
+	// not existing, process err
+	opt.OnErr = func(err error) error { return err }
+	err = Copy("test/data/case17/non-existing", "test/data.copy/case17/non-existing", opt)
+	Expect(t, os.IsNotExist(err)).ToBe(true)
+
+	_, err = os.Stat("test/data.copy/case17/non-existing")
+	Expect(t, os.IsNotExist(err)).ToBe(true)
+
+	// not existing, ignore err
+	opt.OnErr = func(err error) error { return nil }
+	err = Copy("test/data/case17/non-existing", "test/data.copy/case17/non-existing", opt)
+	Expect(t, err).ToBe(nil)
+
+	_, err = os.Stat("test/data.copy/case17/non-existing")
+	Expect(t, os.IsNotExist(err)).ToBe(true)
+}
+
 type SleepyReader struct {
 	src *os.File
 	sec time.Duration

--- a/copy.go
+++ b/copy.go
@@ -19,7 +19,7 @@ func Copy(src, dest string, opts ...Options) error {
 	opt := assureOptions(src, dest, opts...)
 	info, err := os.Lstat(src)
 	if err != nil {
-		return onError(err, opt) // called both, we don't know if it's a file or directory
+		return onError(err, opt)
 	}
 	return switchboard(src, dest, info, opt)
 }

--- a/copy.go
+++ b/copy.go
@@ -242,6 +242,9 @@ func fclose(f *os.File, reported *error) {
 // onError lets caller to handle errors
 // occured when copying a file.
 func onError(err error, opt Options) error {
+	if err == nil {
+		return nil
+	}
 	if opt.OnErr == nil {
 		return err
 	}

--- a/options.go
+++ b/options.go
@@ -14,6 +14,9 @@ type Options struct {
 	// OnDirExists can specify what to do when there is a directory already existing in destination.
 	OnDirExists func(src, dest string) DirExistsAction
 
+	// OnErr lets called decide whether or not to continue on particular copy error.
+	OnErr func(err error) error
+
 	// Skip can specify which files should be skipped
 	Skip func(srcinfo os.FileInfo, src, dest string) (bool, error)
 
@@ -95,6 +98,7 @@ func getDefaultOptions(src, dest string) Options {
 			return Shallow // Do shallow copy
 		},
 		OnDirExists:       nil,                // Default behavior is "Merge".
+		OnErr:             nil,                // Default is "accept error"
 		Skip:              nil,                // Do not skip anything
 		AddPermission:     0,                  // Add nothing
 		PermissionControl: PerservePermission, // Just preserve permission

--- a/options.go
+++ b/options.go
@@ -15,7 +15,7 @@ type Options struct {
 	OnDirExists func(src, dest string) DirExistsAction
 
 	// OnErr lets called decide whether or not to continue on particular copy error.
-	OnErr func(err error) error
+	OnError func(src, dest string, err error) error
 
 	// Skip can specify which files should be skipped
 	Skip func(srcinfo os.FileInfo, src, dest string) (bool, error)
@@ -98,7 +98,7 @@ func getDefaultOptions(src, dest string) Options {
 			return Shallow // Do shallow copy
 		},
 		OnDirExists:       nil,                // Default behavior is "Merge".
-		OnErr:             nil,                // Default is "accept error"
+		OnError:           nil,                // Default is "accept error"
 		Skip:              nil,                // Do not skip anything
 		AddPermission:     0,                  // Add nothing
 		PermissionControl: PerservePermission, // Just preserve permission

--- a/test/data/case17/README.md
+++ b/test/data/case17/README.md
@@ -1,5 +1,5 @@
 So if you wanted to ignore error you should add something like this:
 ```go
-opt.OnFileErr = func(_ error) error { return nil } 
+opt.OnError = func(src, dst string, _ error) error { return nil } 
 ```
 The default value is nil and accepts raised error.

--- a/test/data/case17/README.md
+++ b/test/data/case17/README.md
@@ -1,0 +1,5 @@
+So if you wanted to ignore error you should add something like this:
+```go
+opt.OnFileErr = func(_ error) error { return nil } 
+```
+The default value is nil and accepts raised error.


### PR DESCRIPTION
Please consider this.
This PR introduces `onErr` option in a form of `func(error)error` which lets caller to handler error cases .
It enables caller to log error by error and gives a possibility to continue with copying in case error is not that severe by returning nil (swallowing an error). 