### PR TITLE
Make copying files concurrent

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -21,9 +21,9 @@ type timespec struct {
 func Copy(src, dest string, opts ...Options) error {
 	opt := assureOptions(src, dest, opts...)
 
-	numConcurrentCopies := 1
-	if opt.Concurrency != nil {
-		numConcurrentCopies = opt.Concurrency()
+	var numConcurrentCopies uint = 1
+	if opt.Concurrency > 1 {
+		numConcurrentCopies = opt.Concurrency
 	}
 
 	inCh := make(chan workerInput)
@@ -315,9 +315,9 @@ type workerInput struct {
 
 type workerOutput error
 
-func startWorkers(numWorkers int, inCh chan workerInput, outCh chan workerOutput) {
+func startWorkers(numWorkers uint, inCh chan workerInput, outCh chan workerOutput) {
 	var wg sync.WaitGroup
-	for workerID := 0; workerID < numWorkers; workerID++ {
+	for workerID := uint(0); workerID < numWorkers; workerID++ {
 		wg.Add(1)
 		go worker(&wg, inCh, outCh)
 	}

--- a/copy.go
+++ b/copy.go
@@ -24,7 +24,7 @@ func Copy(src, dest string, opts ...Options) error {
 
 	var numCopyWorkers uint = 1
 	if opt.Concurrency > 1 {
-		numCopyWorkers = opt.Concurrency * 10
+		numCopyWorkers = opt.Concurrency * 100
 	}
 	fmt.Fprintf(os.Stdout, "numCopyWorkers = %d\n", numCopyWorkers)
 

--- a/copy.go
+++ b/copy.go
@@ -26,7 +26,7 @@ func Copy(src, dest string, opts ...Options) error {
 		numConcurrentCopies = opt.Concurrency
 	}
 
-	inCh := make(chan workerInput, numConcurrentCopies)
+	inCh := make(chan workerInput)
 	outCh := make(chan workerOutput, numConcurrentCopies)
 	errCh := make(chan error)
 	go startWorkers(numConcurrentCopies, inCh, outCh)

--- a/copy.go
+++ b/copy.go
@@ -28,7 +28,7 @@ func Copy(src, dest string, opts ...Options) error {
 	}
 	fmt.Fprintf(os.Stdout, "numCopyWorkers = %d\n", numCopyWorkers)
 
-	inCh := make(chan workerInput, numCopyWorkers*10)
+	inCh := make(chan workerInput, numCopyWorkers)
 	outCh := make(chan workerOutput, numCopyWorkers*10)
 	errCh := make(chan error)
 	go startWorkers(numCopyWorkers, inCh, outCh)

--- a/copy.go
+++ b/copy.go
@@ -28,7 +28,7 @@ func Copy(src, dest string, opts ...Options) error {
 	}
 	fmt.Fprintf(os.Stdout, "numCopyWorkers = %d\n", numCopyWorkers)
 
-	inCh := make(chan workerInput, numCopyWorkers*10)
+	inCh := make(chan workerInput, numCopyWorkers*100)
 	outCh := make(chan workerOutput, numCopyWorkers*10)
 	errCh := make(chan error)
 	go startWorkers(numCopyWorkers, inCh, outCh)

--- a/copy.go
+++ b/copy.go
@@ -1,7 +1,6 @@
 package copy
 
 import (
-	"fmt"
 	"go.uber.org/multierr"
 	"io"
 	"io/fs"
@@ -26,7 +25,6 @@ func Copy(src, dest string, opts ...Options) error {
 	if opt.Concurrency > 1 {
 		numCopyWorkers = opt.Concurrency
 	}
-	fmt.Fprintf(os.Stdout, "numCopyWorkers = %d\n", numCopyWorkers)
 
 	inCh := make(chan workerInput, numCopyWorkers)
 	outCh := make(chan workerOutput, numCopyWorkers)

--- a/copy.go
+++ b/copy.go
@@ -1,6 +1,7 @@
 package copy
 
 import (
+	"go.uber.org/multierr"
 	"io"
 	"io/fs"
 	"io/ioutil"
@@ -334,7 +335,7 @@ func worker(wg *sync.WaitGroup, inCh chan workerInput, outCh chan workerOutput) 
 func processResults(out chan workerOutput, result chan error) {
 	var err error
 	for o := range out {
-		err = o // FIXME: collect all
+		err = multierr.Append(err, o)
 	}
 	result <- err
 }

--- a/copy.go
+++ b/copy.go
@@ -29,7 +29,7 @@ func Copy(src, dest string, opts ...Options) error {
 	fmt.Fprintf(os.Stdout, "numCopyWorkers = %d\n", numCopyWorkers)
 
 	inCh := make(chan workerInput, numCopyWorkers*100)
-	outCh := make(chan workerOutput, numCopyWorkers*10)
+	outCh := make(chan workerOutput, numCopyWorkers*1000)
 	errCh := make(chan error)
 	go startWorkers(numCopyWorkers, inCh, outCh)
 	go processResults(outCh, errCh)

--- a/copy.go
+++ b/copy.go
@@ -24,7 +24,7 @@ func Copy(src, dest string, opts ...Options) error {
 
 	var numCopyWorkers uint = 1
 	if opt.Concurrency > 1 {
-		numCopyWorkers = opt.Concurrency * 10
+		numCopyWorkers = opt.Concurrency
 	}
 	fmt.Fprintf(os.Stdout, "numCopyWorkers = %d\n", numCopyWorkers)
 

--- a/copy.go
+++ b/copy.go
@@ -29,7 +29,7 @@ func Copy(src, dest string, opts ...Options) error {
 	fmt.Fprintf(os.Stdout, "numCopyWorkers = %d\n", numCopyWorkers)
 
 	inCh := make(chan workerInput, numCopyWorkers*10)
-	outCh := make(chan workerOutput, numCopyWorkers*100)
+	outCh := make(chan workerOutput, numCopyWorkers*10)
 	errCh := make(chan error)
 	go startWorkers(numCopyWorkers, inCh, outCh)
 	go processResults(outCh, errCh)

--- a/copy.go
+++ b/copy.go
@@ -28,7 +28,7 @@ func Copy(src, dest string, opts ...Options) error {
 	}
 	fmt.Fprintf(os.Stdout, "numCopyWorkers = %d\n", numCopyWorkers)
 
-	inCh := make(chan workerInput, numCopyWorkers*100)
+	inCh := make(chan workerInput, numCopyWorkers*10)
 	outCh := make(chan workerOutput, numCopyWorkers*1000)
 	errCh := make(chan error)
 	go startWorkers(numCopyWorkers, inCh, outCh)

--- a/copy.go
+++ b/copy.go
@@ -29,7 +29,7 @@ func Copy(src, dest string, opts ...Options) error {
 	fmt.Fprintf(os.Stdout, "numCopyWorkers = %d\n", numCopyWorkers)
 
 	inCh := make(chan workerInput, numCopyWorkers)
-	outCh := make(chan workerOutput, numCopyWorkers*10)
+	outCh := make(chan workerOutput, numCopyWorkers)
 	errCh := make(chan error)
 	go startWorkers(numCopyWorkers, inCh, outCh)
 	go processResults(outCh, errCh)

--- a/copy.go
+++ b/copy.go
@@ -28,8 +28,8 @@ func Copy(src, dest string, opts ...Options) error {
 	}
 	fmt.Fprintf(os.Stdout, "numCopyWorkers = %d\n", numCopyWorkers)
 
-	inCh := make(chan workerInput)
-	outCh := make(chan workerOutput, numCopyWorkers)
+	inCh := make(chan workerInput, numCopyWorkers*10)
+	outCh := make(chan workerOutput, numCopyWorkers*10)
 	errCh := make(chan error)
 	go startWorkers(numCopyWorkers, inCh, outCh)
 	go processResults(outCh, errCh)

--- a/copy.go
+++ b/copy.go
@@ -29,7 +29,7 @@ func Copy(src, dest string, opts ...Options) error {
 	fmt.Fprintf(os.Stdout, "numCopyWorkers = %d\n", numCopyWorkers)
 
 	inCh := make(chan workerInput, numCopyWorkers*10)
-	outCh := make(chan workerOutput, numCopyWorkers*1000)
+	outCh := make(chan workerOutput, numCopyWorkers*100)
 	errCh := make(chan error)
 	go startWorkers(numCopyWorkers, inCh, outCh)
 	go processResults(outCh, errCh)

--- a/copy.go
+++ b/copy.go
@@ -24,7 +24,7 @@ func Copy(src, dest string, opts ...Options) error {
 
 	var numCopyWorkers uint = 1
 	if opt.Concurrency > 1 {
-		numCopyWorkers = opt.Concurrency
+		numCopyWorkers = opt.Concurrency * 10
 	}
 	fmt.Fprintf(os.Stdout, "numCopyWorkers = %d\n", numCopyWorkers)
 

--- a/copy.go
+++ b/copy.go
@@ -26,8 +26,8 @@ func Copy(src, dest string, opts ...Options) error {
 		numConcurrentCopies = opt.Concurrency
 	}
 
-	inCh := make(chan workerInput)
-	outCh := make(chan workerOutput)
+	inCh := make(chan workerInput, numConcurrentCopies)
+	outCh := make(chan workerOutput, numConcurrentCopies)
 	errCh := make(chan error)
 	go startWorkers(numConcurrentCopies, inCh, outCh)
 	go processResults(outCh, errCh)

--- a/copy.go
+++ b/copy.go
@@ -24,7 +24,7 @@ func Copy(src, dest string, opts ...Options) error {
 
 	var numCopyWorkers uint = 1
 	if opt.Concurrency > 1 {
-		numCopyWorkers = opt.Concurrency * 100
+		numCopyWorkers = opt.Concurrency * 10
 	}
 	fmt.Fprintf(os.Stdout, "numCopyWorkers = %d\n", numCopyWorkers)
 

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.18
 
 require (
 	github.com/otiai10/mint v1.5.1
+	go.uber.org/multierr v1.11.0
 	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
 github.com/otiai10/mint v1.5.1/go.mod h1:MJm72SBthJjz8qhefc4z1PYEieWmy8Bku7CjcAqyUSM=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/options.go
+++ b/options.go
@@ -65,6 +65,11 @@ type Options struct {
 	// e.g., You can use embed.FS to copy files from embedded filesystem.
 	FS fs.FS
 
+	// If given, returns the number of workers to use to concurrently perform
+	// the copying operation. It the returned value is <= 1, a value of 1 is
+	// used and copying will proceed serially.
+	Concurrency func() int
+
 	intent struct {
 		src  string
 		dest string

--- a/options.go
+++ b/options.go
@@ -68,7 +68,7 @@ type Options struct {
 	// If given, returns the number of workers to use to concurrently perform
 	// the copying operation. It the returned value is <= 1, a value of 1 is
 	// used and copying will proceed serially.
-	Concurrency func() int
+	Concurrency uint
 
 	intent struct {
 		src  string


### PR DESCRIPTION
Copying multiple files concurrently could be faster on systems that use SSDs (as opposed to spinning disks). This PR enhances the `dcopy` function to check if the system is using all SSDs and, if so, copies files concurrently. 

The reason we check if the system is using _all_ SSDs is simply to avoid the complexity of looking up whether the source and destination folders specifically are using using SSDs.

The `github.com/otiai10/copy` module is used by https://github.com/elastic/elastic-agent, a project I work on. I did some manual benchmarking of the changes in this PR here using `elastic-agent`.  You can see the results here: https://github.com/elastic/elastic-agent/pull/3212.

Resolves #81