### PR TITLE
Replace deprecated 'io/ioutil' package with 'os'

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -50,7 +50,7 @@ func TestCopy(t *testing.T) {
 	When(t, "specified src is just a file", func(t *testing.T) {
 		err := Copy("test/data/case01/README.md", "test/data.copy/case01/README.md")
 		Expect(t, err).ToBe(nil)
-		content, err := ioutil.ReadFile("test/data.copy/case01/README.md")
+		content, err := os.ReadFile("test/data.copy/case01/README.md")
 		Expect(t, err).ToBe(nil)
 		Expect(t, string(content)).ToBe("case01 - README.md")
 	})


### PR DESCRIPTION
This PR replaces the deprecated [io/ioutil](https://pkg.go.dev/io/ioutil) package with `os`:

- [`ioutil.ReadDir`](https://pkg.go.dev/io/ioutil#ReadDir) replaced with `os.ReadDir` and additional code to obtain a list of `fs.FileInfo` (the code is pointed out in the doc);
- [`ioutil.ReadFile`](https://pkg.go.dev/io/ioutil#ReadFile) replaced with `os.ReadFile`.