### PR TITLE
Delete obsolete // +build lines

### DIFF
--- a/copy_namedpipes.go
+++ b/copy_namedpipes.go
@@ -1,5 +1,4 @@
 //go:build !windows && !plan9 && !netbsd && !aix && !illumos && !solaris && !js
-// +build !windows,!plan9,!netbsd,!aix,!illumos,!solaris,!js
 
 package copy
 

--- a/copy_namedpipes_x.go
+++ b/copy_namedpipes_x.go
@@ -1,5 +1,4 @@
 //go:build windows || plan9 || netbsd || aix || illumos || solaris || js
-// +build windows plan9 netbsd aix illumos solaris js
 
 package copy
 

--- a/patherror_test.go
+++ b/patherror_test.go
@@ -1,3 +1,5 @@
+//go:build go1.16
+
 package copy
 
 import (

--- a/preserve_ltimes.go
+++ b/preserve_ltimes.go
@@ -1,5 +1,4 @@
 //go:build !windows && !plan9 && !js
-// +build !windows,!plan9,!js
 
 package copy
 

--- a/preserve_ltimes_test.go
+++ b/preserve_ltimes_test.go
@@ -1,5 +1,4 @@
 //go:build !windows && !plan9 && !js
-// +build !windows,!plan9,!js
 
 package copy
 

--- a/preserve_ltimes_x.go
+++ b/preserve_ltimes_x.go
@@ -1,5 +1,4 @@
 //go:build windows || js || plan9
-// +build windows js plan9
 
 package copy
 

--- a/preserve_ltimes_x_test.go
+++ b/preserve_ltimes_x_test.go
@@ -1,5 +1,4 @@
 //go:build windows || js || plan9
-// +build windows js plan9
 
 package copy
 

--- a/preserve_owner.go
+++ b/preserve_owner.go
@@ -1,5 +1,4 @@
 //go:build !windows && !plan9
-// +build !windows,!plan9
 
 package copy
 

--- a/preserve_owner_x.go
+++ b/preserve_owner_x.go
@@ -1,5 +1,4 @@
 //go:build windows || plan9
-// +build windows plan9
 
 package copy
 

--- a/stat_times.go
+++ b/stat_times.go
@@ -1,5 +1,4 @@
 //go:build !windows && !darwin && !freebsd && !plan9 && !netbsd && !js
-// +build !windows,!darwin,!freebsd,!plan9,!netbsd,!js
 
 // TODO: add more runtimes
 

--- a/stat_times_darwin.go
+++ b/stat_times_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package copy
 

--- a/stat_times_freebsd.go
+++ b/stat_times_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd
-// +build freebsd
 
 package copy
 

--- a/stat_times_js.go
+++ b/stat_times_js.go
@@ -1,5 +1,4 @@
 //go:build js
-// +build js
 
 package copy
 

--- a/stat_times_windows.go
+++ b/stat_times_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package copy
 

--- a/stat_times_x.go
+++ b/stat_times_x.go
@@ -1,5 +1,4 @@
 //go:build plan9 || netbsd
-// +build plan9 netbsd
 
 package copy
 

--- a/symlink_test.go
+++ b/symlink_test.go
@@ -1,5 +1,4 @@
 //go:build !windows && !plan9 && !netbsd && !aix && !illumos && !solaris && !js
-// +build !windows,!plan9,!netbsd,!aix,!illumos,!solaris,!js
 
 package copy
 

--- a/symlink_test_x.go
+++ b/symlink_test_x.go
@@ -1,5 +1,4 @@
 //go:build windows || plan9 || netbsd || aix || illumos || solaris || js
-// +build windows plan9 netbsd aix illumos solaris js
 
 package copy
 

--- a/test/images/alpine.Dockerfile
+++ b/test/images/alpine.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.16
 
 WORKDIR /app
 

--- a/test_setup_test.go
+++ b/test_setup_test.go
@@ -1,5 +1,4 @@
 //go:build !windows && !plan9 && !netbsd && !aix && !illumos && !solaris && !js
-// +build !windows,!plan9,!netbsd,!aix,!illumos,!solaris,!js
 
 package copy
 

--- a/test_setup_x_test.go
+++ b/test_setup_x_test.go
@@ -1,5 +1,4 @@
 //go:build windows || plan9 || netbsd || aix || illumos || solaris || js
-// +build windows plan9 netbsd aix illumos solaris js
 
 package copy
 


### PR DESCRIPTION
This PR removes outdated `// +build` build constraints. Use `go fix ./...` to remove the `// +build` lines that have become obsolete in Go 1.18. See https://go.dev/doc/go1.18#go-build-lines.

[Alpine 3.16](https://www.alpinelinux.org/posts/Alpine-3.16.0-released.html) is needed because it has Go 1.18.