### PR TITLE
Overwrite symlink

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -65,7 +65,7 @@ func TestCopy(t *testing.T) {
 
 	When(t, "try to copy to an existing path", func(t *testing.T) {
 		err := Copy("test/data/case03", "test/data.copy/case03")
-		Expect(t, err).Not().ToBe(nil)
+		Expect(t, err).ToBe(nil)
 	})
 
 	When(t, "try to copy READ-not-allowed source", func(t *testing.T) {

--- a/copy.go
+++ b/copy.go
@@ -321,6 +321,15 @@ func lcopy(src, dest string) error {
 		}
 		return err
 	}
+
+	// @See https://github.com/otiai10/copy/issues/132
+	// TODO: Control by SymlinkExistsAction
+	if _, err := os.Lstat(dest); err == nil {
+		if err := os.Remove(dest); err != nil {
+			return err
+		}
+	}
+
 	return os.Symlink(orig, dest)
 }
 


### PR DESCRIPTION
Solves https://github.com/otiai10/copy/issues/132.

The behavior of `copy` by default is to overwrite files, i'm doing the same for symlinks here.