### PR TITLE
Add copy-on-write support when using MacOS.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         go: ['1.18', '1.19', '1.20']
+        tags: ['', 'test_cow']
     steps:
     - name: Set up Go
       uses: actions/setup-go@v4
@@ -32,7 +33,7 @@ jobs:
       run: go build -v .
 
     - name: Test
-      run: go test -v --tags=go${{ matrix.go }}
+      run: go test -v --tags=go${{ matrix.go }},${{ matrix.tags }}
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor
 
 # Test Specific
 test/data/case16/large.file
+test/data/case21/larger.file

--- a/all_test.go
+++ b/all_test.go
@@ -30,12 +30,12 @@ func teardown(m *testing.M) {
 	os.RemoveAll("test/data.copy")
 	os.RemoveAll("test/data.copyTime")
 	os.RemoveAll("test/owned-by-root") // Do not check the error ;)
-	Copy("test/data/case18/assets.backup", "test/data/case18/assets")
+	CopyInTest("test/data/case18/assets.backup", "test/data/case18/assets")
 	os.RemoveAll("test/data/case18/assets.backup")
 }
 
 func TestCopy(t *testing.T) {
-	err := Copy("./test/data/case00", "./test/data.copy/case00")
+	err := CopyInTest("./test/data/case00", "./test/data.copy/case00")
 	Expect(t, err).ToBe(nil)
 	info, err := os.Stat("./test/data.copy/case00/README.md")
 	Expect(t, err).ToBe(nil)
@@ -43,12 +43,12 @@ func TestCopy(t *testing.T) {
 	Expect(t, info.IsDir()).ToBe(false)
 
 	When(t, "specified src doesn't exist", func(t *testing.T) {
-		err := Copy("NOT/EXISTING/SOURCE/PATH", "anywhere")
+		err := CopyInTest("NOT/EXISTING/SOURCE/PATH", "anywhere")
 		Expect(t, err).Not().ToBe(nil)
 	})
 
 	When(t, "specified src is just a file", func(t *testing.T) {
-		err := Copy("test/data/case01/README.md", "test/data.copy/case01/README.md")
+		err := CopyInTest("test/data/case01/README.md", "test/data.copy/case01/README.md")
 		Expect(t, err).ToBe(nil)
 		content, err := os.ReadFile("test/data.copy/case01/README.md")
 		Expect(t, err).ToBe(nil)
@@ -56,7 +56,7 @@ func TestCopy(t *testing.T) {
 	})
 
 	When(t, "source directory includes symbolic link", func(t *testing.T) {
-		err := Copy("test/data/case03", "test/data.copy/case03")
+		err := CopyInTest("test/data/case03", "test/data.copy/case03")
 		Expect(t, err).ToBe(nil)
 		info, err := os.Lstat("test/data.copy/case03/case01")
 		Expect(t, err).ToBe(nil)
@@ -64,19 +64,19 @@ func TestCopy(t *testing.T) {
 	})
 
 	When(t, "try to copy to an existing path", func(t *testing.T) {
-		err := Copy("test/data/case03", "test/data.copy/case03")
+		err := CopyInTest("test/data/case03", "test/data.copy/case03")
 		Expect(t, err).ToBe(nil)
 	})
 
 	When(t, "try to copy READ-not-allowed source", func(t *testing.T) {
-		err := Copy("test/data/doesNotExist", "test/data.copy/doesNotExist")
+		err := CopyInTest("test/data/doesNotExist", "test/data.copy/doesNotExist")
 		Expect(t, err).Not().ToBe(nil)
 	})
 
 	When(t, "try to copy a file to existing path", func(t *testing.T) {
-		err := Copy("test/data/case04/README.md", "test/data/case04")
+		err := CopyInTest("test/data/case04/README.md", "test/data/case04")
 		Expect(t, err).Not().ToBe(nil)
-		err = Copy("test/data/case04/README.md", "test/data/case04/README.md/foobar")
+		err = CopyInTest("test/data/case04/README.md", "test/data/case04/README.md/foobar")
 		Expect(t, err).Not().ToBe(nil)
 	})
 
@@ -85,7 +85,7 @@ func TestCopy(t *testing.T) {
 		dest := "test/data.copy/case05"
 		err := os.Chmod(src, os.FileMode(0o555))
 		Expect(t, err).ToBe(nil)
-		err = Copy(src, dest)
+		err = CopyInTest(src, dest)
 		Expect(t, err).ToBe(nil)
 		info, err := os.Lstat(dest)
 		Expect(t, err).ToBe(nil)
@@ -106,7 +106,7 @@ func TestCopy(t *testing.T) {
 			os.Remove(src)
 			return false, nil
 		}}
-		err = Copy(src, dest, opt)
+		err = CopyInTest(src, dest, opt)
 		Expect(t, err).ToBe(nil)
 	})
 	When(t, "symlink is deleted while copying", func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestCopy(t *testing.T) {
 			os.Remove(src)
 			return false, nil
 		}}
-		err = Copy(src, dest, opt)
+		err = CopyInTest(src, dest, opt)
 		Expect(t, err).ToBe(nil)
 	})
 	When(t, "directory is deleted while copying", func(t *testing.T) {
@@ -132,7 +132,7 @@ func TestCopy(t *testing.T) {
 			os.Remove(src)
 			return false, nil
 		}}
-		err = Copy(src, dest, opt)
+		err = CopyInTest(src, dest, opt)
 		Expect(t, err).ToBe(nil)
 	})
 }
@@ -144,7 +144,7 @@ func TestCopy_NamedPipe(t *testing.T) {
 
 	When(t, "specified src contains a folder with a named pipe", func(t *testing.T) {
 		dest := "test/data.copy/case11"
-		err := Copy("test/data/case11", dest)
+		err := CopyInTest("test/data/case11", dest)
 		Expect(t, err).ToBe(nil)
 
 		info, err := os.Lstat("test/data/case11/foo/bar")
@@ -155,7 +155,7 @@ func TestCopy_NamedPipe(t *testing.T) {
 
 	When(t, "specified src is a named pipe", func(t *testing.T) {
 		dest := "test/data.copy/case11/foo/bar.named"
-		err := Copy("test/data/case11/foo/bar", dest)
+		err := CopyInTest("test/data/case11/foo/bar", dest)
 		Expect(t, err).ToBe(nil)
 
 		info, err := os.Lstat(dest)
@@ -176,7 +176,7 @@ func TestOptions_Skip(t *testing.T) {
 			return false, nil
 		}
 	}}
-	err := Copy("test/data/case06", "test/data.copy/case06", opt)
+	err := CopyInTest("test/data/case06", "test/data.copy/case06", opt)
 	Expect(t, err).ToBe(nil)
 	info, err := os.Stat("./test/data.copy/case06/dir_skip")
 	Expect(t, info).ToBe(nil)
@@ -203,7 +203,7 @@ func TestOptions_Skip(t *testing.T) {
 		opt := Options{Skip: func(info os.FileInfo, src, dest string) (bool, error) {
 			return false, errInsideSkipFunc
 		}}
-		err := Copy("test/data/case06", "test/data.copy/case06.01", opt)
+		err := CopyInTest("test/data/case06", "test/data.copy/case06.01", opt)
 		Expect(t, err).ToBe(errInsideSkipFunc)
 		files, err := os.ReadDir("./test/data.copy/case06.01")
 		Expect(t, err).ToBe(nil)
@@ -213,7 +213,7 @@ func TestOptions_Skip(t *testing.T) {
 
 func TestOptions_Specials(t *testing.T) {
 	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
-		err := Copy("/dev/null", "test/data.copy/dev-null", Options{Specials: false})
+		err := CopyInTest("/dev/null", "test/data.copy/dev-null", Options{Specials: false})
 		Expect(t, err).ToBe(nil)
 	}
 }
@@ -228,7 +228,7 @@ func TestOptions_PermissionControl(t *testing.T) {
 	Expect(t, info.Mode()).ToBe(os.FileMode(0o444))
 
 	opt := Options{PermissionControl: AddPermission(0o222)}
-	err = Copy("test/data/case07", "test/data.copy/case07", opt)
+	err = CopyInTest("test/data/case07", "test/data.copy/case07", opt)
 	Expect(t, err).ToBe(nil)
 
 	info, err = os.Stat("test/data.copy/case07/dir_0555")
@@ -240,7 +240,7 @@ func TestOptions_PermissionControl(t *testing.T) {
 	Expect(t, info.Mode()).ToBe(os.FileMode(0o444 | 0o222))
 
 	When(t, "try to copy a dir owned by other users", func(t *testing.T) {
-		err := Copy("test/data/case14", "test/owned-by-root", Options{
+		err := CopyInTest("test/data/case14", "test/owned-by-root", Options{
 			PermissionControl: DoNothing, // ONLY docker tests fail when you comment out this line
 		})
 		Expect(t, err).ToBe(nil)
@@ -251,15 +251,15 @@ func TestOptions_Sync(t *testing.T) {
 	// With Sync option, each file will be flushed to storage on copying.
 	// TODO: Since it's a bit hard to simulate real usecases here. This testcase is nonsense.
 	opt := Options{Sync: true}
-	err := Copy("test/data/case08", "test/data.copy/case08", opt)
+	err := CopyInTest("test/data/case08", "test/data.copy/case08", opt)
 	Expect(t, err).ToBe(nil)
 }
 
 func TestOptions_PreserveTimes(t *testing.T) {
-	err := Copy("test/data/case09", "test/data.copy/case09")
+	err := CopyInTest("test/data/case09", "test/data.copy/case09")
 	Expect(t, err).ToBe(nil)
 	opt := Options{PreserveTimes: true}
-	err = Copy("test/data/case09", "test/data.copy/case09-preservetimes", opt)
+	err = CopyInTest("test/data/case09", "test/data.copy/case09-preservetimes", opt)
 	Expect(t, err).ToBe(nil)
 
 	for _, entry := range []string{"", "README.md", "symlink"} {
@@ -275,11 +275,11 @@ func TestOptions_PreserveTimes(t *testing.T) {
 }
 
 func TestOptions_OnDirExists(t *testing.T) {
-	err := Copy("test/data/case10/dest", "test/data.copy/case10/dest.1")
+	err := CopyInTest("test/data/case10/dest", "test/data.copy/case10/dest.1")
 	Expect(t, err).ToBe(nil)
-	err = Copy("test/data/case10/dest", "test/data.copy/case10/dest.2")
+	err = CopyInTest("test/data/case10/dest", "test/data.copy/case10/dest.2")
 	Expect(t, err).ToBe(nil)
-	err = Copy("test/data/case10/dest", "test/data.copy/case10/dest.3")
+	err = CopyInTest("test/data/case10/dest", "test/data.copy/case10/dest.3")
 	Expect(t, err).ToBe(nil)
 
 	opt := Options{}
@@ -287,9 +287,9 @@ func TestOptions_OnDirExists(t *testing.T) {
 	opt.OnDirExists = func(src, dest string) DirExistsAction {
 		return Merge
 	}
-	err = Copy("test/data/case10/src", "test/data.copy/case10/dest.1", opt)
+	err = CopyInTest("test/data/case10/src", "test/data.copy/case10/dest.1", opt)
 	Expect(t, err).ToBe(nil)
-	err = Copy("test/data/case10/src", "test/data.copy/case10/dest.1", opt)
+	err = CopyInTest("test/data/case10/src", "test/data.copy/case10/dest.1", opt)
 	Expect(t, err).ToBe(nil)
 	b, err := os.ReadFile("test/data.copy/case10/dest.1/" + "foo/" + "text_aaa")
 	Expect(t, err).ToBe(nil)
@@ -301,9 +301,9 @@ func TestOptions_OnDirExists(t *testing.T) {
 	opt.OnDirExists = func(src, dest string) DirExistsAction {
 		return Replace
 	}
-	err = Copy("test/data/case10/src", "test/data.copy/case10/dest.2", opt)
+	err = CopyInTest("test/data/case10/src", "test/data.copy/case10/dest.2", opt)
 	Expect(t, err).ToBe(nil)
-	err = Copy("test/data/case10/src", "test/data.copy/case10/dest.2", opt)
+	err = CopyInTest("test/data/case10/src", "test/data.copy/case10/dest.2", opt)
 	Expect(t, err).ToBe(nil)
 	b, err = os.ReadFile("test/data.copy/case10/dest.2/" + "foo/" + "text_aaa")
 	Expect(t, err).ToBe(nil)
@@ -315,7 +315,7 @@ func TestOptions_OnDirExists(t *testing.T) {
 	opt.OnDirExists = func(src, dest string) DirExistsAction {
 		return Untouchable
 	}
-	err = Copy("test/data/case10/src", "test/data.copy/case10/dest.3", opt)
+	err = CopyInTest("test/data/case10/src", "test/data.copy/case10/dest.3", opt)
 	Expect(t, err).ToBe(nil)
 	b, err = os.ReadFile("test/data.copy/case10/dest.3/" + "foo/" + "text_aaa")
 	Expect(t, err).ToBe(nil)
@@ -326,7 +326,7 @@ func TestOptions_OnDirExists(t *testing.T) {
 			OnDirExists:   func(src, dest string) DirExistsAction { return Untouchable },
 			PreserveTimes: true,
 		}
-		err = Copy("test/data/case10/src", "test/data.copy/case10/dest.3", opt)
+		err = CopyInTest("test/data/case10/src", "test/data.copy/case10/dest.3", opt)
 		Expect(t, err).ToBe(nil)
 	})
 }
@@ -336,7 +336,7 @@ func TestOptions_CopyBufferSize(t *testing.T) {
 		CopyBufferSize: 512,
 	}
 
-	err := Copy("test/data/case12", "test/data.copy/case12", opt)
+	err := CopyInTest("test/data/case12", "test/data.copy/case12", opt)
 	Expect(t, err).ToBe(nil)
 
 	content, err := os.ReadFile("test/data.copy/case12/README.md")
@@ -346,11 +346,15 @@ func TestOptions_CopyBufferSize(t *testing.T) {
 
 func TestOptions_PreserveOwner(t *testing.T) {
 	opt := Options{PreserveOwner: true}
-	err := Copy("test/data/case13", "test/data.copy/case13", opt)
+	err := CopyInTest("test/data/case13", "test/data.copy/case13", opt)
 	Expect(t, err).ToBe(nil)
 }
 
 func TestOptions_CopyRateLimit(t *testing.T) {
+	if isTestingCopyOnWrite {
+		t.Skip("Copy-on-write is incompatible with rate limiting.")
+		return
+	}
 
 	file, err := os.Create("test/data/case16/large.file")
 	if err != nil {
@@ -370,7 +374,7 @@ func TestOptions_CopyRateLimit(t *testing.T) {
 	}}
 
 	start := time.Now()
-	err = Copy("test/data/case16", "test/data.copy/case16", opt)
+	err = CopyInTest("test/data/case16", "test/data.copy/case16", opt)
 	elapsed := time.Since(start)
 	Expect(t, err).ToBe(nil)
 	Expect(t, elapsed > 5*time.Second).ToBe(true)
@@ -382,11 +386,11 @@ func TestOptions_OnFileError(t *testing.T) {
 	}
 
 	// existing, process normally
-	err := Copy("test/data/case17", "test/data.copy/case17", opt)
+	err := CopyInTest("test/data/case17", "test/data.copy/case17", opt)
 	Expect(t, err).ToBe(nil)
 
 	// not existing, process err
-	err = Copy("test/data/case17/non-existing", "test/data.copy/case17/non-existing", opt)
+	err = CopyInTest("test/data/case17/non-existing", "test/data.copy/case17/non-existing", opt)
 	Expect(t, os.IsNotExist(err)).ToBe(true)
 
 	_, err = os.Stat("test/data.copy/case17/non-existing")
@@ -396,12 +400,12 @@ func TestOptions_OnFileError(t *testing.T) {
 	opt.OnError = func(_, _ string, err error) error {
 		return err
 	}
-	err = Copy("test/data/case17", "test/data.copy/case17", opt)
+	err = CopyInTest("test/data/case17", "test/data.copy/case17", opt)
 	Expect(t, err).ToBe(nil)
 
 	// not existing, process err
 	opt.OnError = func(_, _ string, err error) error { return err }
-	err = Copy("test/data/case17/non-existing", "test/data.copy/case17/non-existing", opt)
+	err = CopyInTest("test/data/case17/non-existing", "test/data.copy/case17/non-existing", opt)
 	Expect(t, os.IsNotExist(err)).ToBe(true)
 
 	_, err = os.Stat("test/data.copy/case17/non-existing")
@@ -409,7 +413,7 @@ func TestOptions_OnFileError(t *testing.T) {
 
 	// not existing, ignore err
 	opt.OnError = func(_, _ string, err error) error { return nil }
-	err = Copy("test/data/case17/non-existing", "test/data.copy/case17/non-existing", opt)
+	err = CopyInTest("test/data/case17/non-existing", "test/data.copy/case17/non-existing", opt)
 	Expect(t, err).ToBe(nil)
 
 	_, err = os.Stat("test/data.copy/case17/non-existing")
@@ -418,7 +422,7 @@ func TestOptions_OnFileError(t *testing.T) {
 
 func TestOptions_FS(t *testing.T) {
 	os.RemoveAll("test/data/case18/assets")
-	err := Copy("test/data/case18/assets", "test/data.copy/case18/assets", Options{
+	err := CopyInTest("test/data/case18/assets", "test/data.copy/case18/assets", Options{
 		FS:                assets,
 		PermissionControl: AddPermission(200), // FIXME
 	})
@@ -443,7 +447,7 @@ func (r *SleepyReader) Read(p []byte) (int, error) {
 
 func TestOptions_NumOfWorkers(t *testing.T) {
 	opt := Options{NumOfWorkers: 3}
-	err := Copy("test/data/case19", "test/data.copy/case19", opt)
+	err := CopyInTest("test/data/case19", "test/data.copy/case19", opt)
 	Expect(t, err).ToBe(nil)
 }
 
@@ -451,7 +455,7 @@ func TestOptions_PreferConcurrent(t *testing.T) {
 	opt := Options{NumOfWorkers: 4, PreferConcurrent: func(sd, dd string) (bool, error) {
 		return strings.HasSuffix(sd, "concurrent"), nil
 	}}
-	err := Copy("test/data/case19", "test/data.copy/case19_preferconcurrent", opt)
+	err := CopyInTest("test/data/case19", "test/data.copy/case19_preferconcurrent", opt)
 	Expect(t, err).ToBe(nil)
 }
 
@@ -467,7 +471,7 @@ func TestOptions_RenameDestination(t *testing.T) {
 			return d, nil // otherwise do nothing
 		},
 	}
-	err := Copy("test/data/case20", "test/data.copy/case20", opt)
+	err := CopyInTest("test/data/case20", "test/data.copy/case20", opt)
 	Expect(t, err).ToBe(nil)
 	_, err = os.Stat("test/data.copy/case20/foo/main.go.template")
 	Expect(t, os.IsNotExist(err)).ToBe(true)
@@ -498,7 +502,7 @@ func TestOptions_CopyOnWrite(t *testing.T) {
 	}
 
 	// Copy it using CoW.
-	err = Copy("test/data/case21", "test/data.copy/case21", Options{
+	err = CopyInTest("test/data/case21", "test/data.copy/case21", Options{
 		CopyOnWrite: CopyOnWriteRequired,
 	})
 

--- a/copy.go
+++ b/copy.go
@@ -86,6 +86,9 @@ func copyNextOrSkip(src, dest string, info os.FileInfo, opt Options) error {
 // with considering existence of parent directory
 // and file permission.
 func fcopy(src, dest string, info os.FileInfo, opt Options) (err error) {
+	if err = os.MkdirAll(filepath.Dir(dest), os.ModePerm); err != nil {
+		return
+	}
 
 	var readcloser io.ReadCloser
 	if opt.FS != nil {
@@ -100,10 +103,6 @@ func fcopy(src, dest string, info os.FileInfo, opt Options) (err error) {
 		return
 	}
 	defer fclose(readcloser, &err)
-
-	if err = os.MkdirAll(filepath.Dir(dest), os.ModePerm); err != nil {
-		return
-	}
 
 	f, err := os.Create(dest)
 	if err != nil {

--- a/cow.go
+++ b/cow.go
@@ -1,0 +1,10 @@
+package copy
+
+import "errors"
+
+// ErrNoCOW is the error returned when copy-on-write is not possible.
+//
+// To check for this error:
+//
+//	errors.Is(err, copy.ErrNoCOW)
+var ErrNoCOW = errors.New("copy-on-write not possible")

--- a/cow_darwin.go
+++ b/cow_darwin.go
@@ -1,0 +1,58 @@
+//go:build darwin
+
+package copy
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+const platformSupportsCopyOnWrite = true
+
+// Darwin implementation uses the `clonefile` syscall:
+// https://www.manpagez.com/man/2/clonefile/
+//
+// Considerations:
+//  * Ownership is not preserved.
+//  * Setuid and Setgid are not preserved.
+//  * Flag CLONE_NOFOLLOW is not used, we use lcopy instead of fcopy for
+//    symbolic links.
+
+func fcopyOnWrite(src, dest string, info os.FileInfo, opt Options) (err error) {
+	err = unix.Clonefile(src, dest, 0)
+
+	// If the error is the file already exists, delete it and try again.
+	// When/if an option for OnFileExists is added, this can be handled
+	// differently.
+	if errors.Is(err, os.ErrExist) {
+		if err = os.Remove(dest); err != nil {
+			return fmt.Errorf("%w: %w", ErrNoCOW, err)
+		}
+
+		err = unix.Clonefile(src, dest, 0) // retry
+	}
+
+	// Return an ErrNoCOW if copy-on-write is not possible.
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrNoCOW, err)
+	}
+
+	// Copy-on-write preserves the modtime by default.
+	// If PreserveTimes is not true, update the time to now.
+	if !opt.PreserveTimes {
+		if err = touchTimes(dest); err != nil {
+			return err
+		}
+	}
+
+	// Apply permission control to the copied file.
+	//
+	// Unlike fcopyBytes, this is done after-the-fact since we don't
+	// actually open the dest file at any point.
+	err = applyPermissionControl(dest, info, opt)
+
+	return
+}

--- a/cow_x.go
+++ b/cow_x.go
@@ -1,3 +1,5 @@
+//go:build !darwin
+
 package copy
 
 import "os"

--- a/cow_x.go
+++ b/cow_x.go
@@ -1,0 +1,11 @@
+package copy
+
+import "os"
+
+const platformSupportsCopyOnWrite = false
+
+// fcopyOnWrite tries to copy a file using the platform's copy-on-write
+// mechanism
+func fcopyOnWrite(src, dest string, info os.FileInfo, opt Options) (err error) {
+	return ErrNoCOW
+}

--- a/options.go
+++ b/options.go
@@ -167,6 +167,8 @@ func getDefaultOptions(src, dest string) Options {
 
 // assureOptions struct, should be called only once.
 // All optional values MUST NOT BE nil/zero after assured.
+//
+// FIXME: Isn't this supposed to merge the options?
 func assureOptions(src, dest string, opts ...Options) Options {
 	defopt := getDefaultOptions(src, dest)
 	if len(opts) == 0 {

--- a/preserve_times.go
+++ b/preserve_times.go
@@ -1,10 +1,21 @@
 package copy
 
-import "os"
+import (
+	"os"
+	"time"
+)
 
 func preserveTimes(srcinfo os.FileInfo, dest string) error {
 	spec := getTimeSpec(srcinfo)
 	if err := os.Chtimes(dest, spec.Atime, spec.Mtime); err != nil {
+		return err
+	}
+	return nil
+}
+
+func touchTimes(dest string) error {
+	now := time.Now()
+	if err := os.Chtimes(dest, now, now); err != nil {
 		return err
 	}
 	return nil

--- a/test/data/case21/README.md
+++ b/test/data/case21/README.md
@@ -1,0 +1,3 @@
+This tests the copy-on-write functionality.
+
+A 32 megabyte file is created to demonstrate performance.

--- a/test_tags_cow_test.go
+++ b/test_tags_cow_test.go
@@ -1,0 +1,15 @@
+//go:build test_cow
+
+package copy
+
+// For this test, we want to run all the tests with CopyOnWritePreferred.
+//
+// This ensures that everything still functions as expected when CopyOnWrite
+// is enabled.
+const isTestingCopyOnWrite = true
+
+func CopyInTest(src, dest string, opts ...Options) error {
+	opt := assureOptions(src, dest, opts...)
+	opt.CopyOnWrite = CopyOnWritePreferred
+	return Copy(src, dest, opt)
+}

--- a/test_tags_x_test.go
+++ b/test_tags_x_test.go
@@ -1,0 +1,9 @@
+//go:build !test_cow
+
+package copy
+
+const isTestingCopyOnWrite = false
+
+func CopyInTest(src, dest string, opts ...Options) error {
+	return Copy(src, dest, opts...)
+}


### PR DESCRIPTION
This series of commits adds support for using the [clonefile](https://www.manpagez.com/man/2/clonefile/) syscall for copying regular files using APFS's copy-on-write mechanism.

It's implemented in a way that:

 * Is opt-in, rather than opt-out.
 * Has three settings:
   1. `NeverCopyOnWrite` (default) 
   2. `CopyOnWritePreferred` — try to copy-on-write, fall back to copying contents if that fails
   3. `CopyOnWriteRequired` — require copy-on-write to succeed when the platform is supported
 * Is tested.
   * I added a `-tags=test_cow` flag for tests so it can run all the normal tests using `CopyOnWritePreferred`.
   * I updated the CI matrix to run tests both with `test_cow` and without.
 * Asks for forgiveness rather than permission.
   * The operating system is already performing validity checks.
   * It's less syscall overhead and code to try and fail copy-on-write than to check if it's possible first.

This pull request doesn't include Linux support, as I don't currently have access to a Linux machine running btrfs.
It should be fairly straightforward to use the syscalls for it, though: https://stackoverflow.com/a/52799021

## Benchmarks

Environment is a M1 MacBook Pro.


### Part 1: Performance Impact for Non-CoW Usage

These Benchmarks are performed by running `go test -count=1` 10 times.

**Benchmark @ origin/main**

```
ok      github.com/otiai10/copy 5.272s
ok      github.com/otiai10/copy 5.261s
ok      github.com/otiai10/copy 5.274s
ok      github.com/otiai10/copy 5.270s
ok      github.com/otiai10/copy 5.267s
ok      github.com/otiai10/copy 5.268s
ok      github.com/otiai10/copy 5.277s
ok      github.com/otiai10/copy 5.242s
ok      github.com/otiai10/copy 5.254s
ok      github.com/otiai10/copy 5.262s

min: 5.242s
max: 5.277s
avg: 5.2647s
```

Baseline.

**Benchmark @ 6bf4915 **

```
ok      github.com/otiai10/copy 5.256s
ok      github.com/otiai10/copy 5.276s
ok      github.com/otiai10/copy 5.256s
ok      github.com/otiai10/copy 5.269s
ok      github.com/otiai10/copy 5.252s
ok      github.com/otiai10/copy 5.273s
ok      github.com/otiai10/copy 5.280s
ok      github.com/otiai10/copy 5.276s
ok      github.com/otiai10/copy 5.266s
ok      github.com/otiai10/copy 5.259s

min: 5.252s
max: 5.280s
avg: 5.2671s
```

Conclusion: With the extra abstraction, the difference is negligible. If anything, it's likely noise from inconsistent IO speeds or background processes.

### Part 2: Performance Impact for CoW Usage

These benchmarks are performed by running `go test -run '^TestOptions_CopyOnWrite$' -count=1` 10 times.
With the file size being 32 MiB, these are the results:

**Benchmark @ 6b56d09 **

```
ok      github.com/otiai10/copy 0.226s
ok      github.com/otiai10/copy 0.235s
ok      github.com/otiai10/copy 0.218s
ok      github.com/otiai10/copy 0.233s
ok      github.com/otiai10/copy 0.247s
ok      github.com/otiai10/copy 0.241s
ok      github.com/otiai10/copy 0.230s
ok      github.com/otiai10/copy 0.223s
ok      github.com/otiai10/copy 0.237s
ok      github.com/otiai10/copy 0.225s

min: 0.218s
max: 0.247s
avg: 0.2315s
```

Baseline.

**Benchmark @ c97ba43 **

```
ok      github.com/otiai10/copy 0.200s
ok      github.com/otiai10/copy 0.200s
ok      github.com/otiai10/copy 0.220s
ok      github.com/otiai10/copy 0.204s
ok      github.com/otiai10/copy 0.211s
ok      github.com/otiai10/copy 0.218s
ok      github.com/otiai10/copy 0.220s
ok      github.com/otiai10/copy 0.207s
ok      github.com/otiai10/copy 0.214s
ok      github.com/otiai10/copy 0.211s

min: 0.200s
max: 0.220s
avg: 0.2105s
```

Conclusion: A small improvement for a 32 MiB file.

I also tested a 16 GiB file, and it goes down from 8.058s to 0.381s.