### PR TITLE
test: Add testing for FileCopyMethod

### DIFF
--- a/.github/workflows/filecopymethod-test.yml
+++ b/.github/workflows/filecopymethod-test.yml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         environment:
          - filesystem: btrfs
+           filecopymethod: CopyBytes
     steps:
     - name: Set up Go
       uses: actions/setup-go@v4
@@ -56,6 +57,8 @@ jobs:
     - name: Test
       working-directory: test/filesystem/mounted
       run: go test -v
+      env:
+        TEST_FILECOPYMETHOD: ${{matrix.environment.filecopymethod}}
 
 
   test-macos:
@@ -65,6 +68,7 @@ jobs:
       matrix:
         environment:
          - filesystem: APFS
+           filecopymethod: CopyBytes
     steps:
     - name: Set up Go
       uses: actions/setup-go@v4
@@ -96,3 +100,5 @@ jobs:
     - name: Test
       working-directory: test/filesystem/mounted
       run: go test -v
+      env:
+        TEST_FILECOPYMETHOD: ${{matrix.environment.filecopymethod}}

--- a/.github/workflows/filecopymethod-test.yml
+++ b/.github/workflows/filecopymethod-test.yml
@@ -1,0 +1,98 @@
+# Some platform-specific file copy syscalls (e.g. creating reflinks) are only
+# supported on some platforms, and only with specific filesystems. These
+# syscalls are used by different FileCopyMethod implementations.
+#
+# This workflow sets up the conditions needed for those syscalls to work,
+# and then runs the tests with the different FileCopyMethods.
+
+name: FileCopyMethod
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+jobs:
+  test-linux:
+    name: Test Linux
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment:
+         - filesystem: btrfs
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 'stable'
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
+    - name: Get dependencies
+      run: go get -v -t -d ./...
+
+    - name: Build
+      run: go build -v .
+
+    - name: Set up filesystem
+      run: |-
+        mkdir -p ./test/filesystem
+        IMAGE_PATH="./test/filesystem/contents.img"
+        MOUNT_PATH="./test/filesystem/mounted"
+
+        truncate -s 500m "$IMAGE_PATH"
+        mkfs -t "${{matrix.environment.filesystem}}" "$IMAGE_PATH"
+        mkdir "$MOUNT_PATH"
+        sudo mount -o loop "$IMAGE_PATH" "$MOUNT_PATH"
+        sudo chown -R "$(id -u):$(id -g)" "$MOUNT_PATH"
+
+    - name: Copy files to mounted filesystem
+      run: |-
+        rsync -av --exclude=".*" --exclude "test/filesystem" . "test/filesystem/mounted"
+
+    - name: Test
+      working-directory: test/filesystem/mounted
+      run: go test -v
+
+
+  test-macos:
+    name: Test MacOS
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        environment:
+         - filesystem: APFS
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 'stable'
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
+    - name: Get dependencies
+      run: go get -v -t -d ./...
+
+    - name: Build
+      run: go build -v .
+
+    - name: Set up filesystem (MacOS)
+      run: |-
+        mkdir -p ./test/filesystem
+        IMAGE_PATH="./test/filesystem/contents.dmg"
+        MOUNT_PATH="./test/filesystem/mounted"
+
+        hdiutil create -size 500m -fs "${{matrix.environment.filesystem}}" "$IMAGE_PATH"
+        hdiutil attach -mountpoint "$MOUNT_PATH" "$IMAGE_PATH"
+
+    - name: Copy files to mounted filesystem
+      run: |-
+        rsync -av --exclude=".*" --exclude "test/filesystem" . "test/filesystem/mounted"
+
+    - name: Test
+      working-directory: test/filesystem/mounted
+      run: go test -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 test/data.copy
+test/filesystem
 test/owned-by-root
 coverage.txt
 vendor

--- a/all_test.go
+++ b/all_test.go
@@ -445,7 +445,12 @@ func TestOptions_FS(t *testing.T) {
 		FS:                assets,
 		PermissionControl: AddPermission(200), // FIXME
 	})
-	Expect(t, err).ToBe(nil)
+	if currentFileCopyMethod.supportsOptFS {
+		Expect(t, err).ToBe(nil)
+	} else {
+		Expect(t, err).Not().ToBe(nil)
+		Expect(t, errors.Is(err, ErrUnsupportedCopyMethod)).ToBe(true)
+	}
 }
 
 type SleepyReader struct {

--- a/all_test.go
+++ b/all_test.go
@@ -17,8 +17,27 @@ import (
 //go:embed test/data/case18/assets
 var assets embed.FS
 
+var currentFileCopyMethod FileCopyMethod
+
+func setupFileCopyMethod(m *testing.M) {
+	switch os.Getenv("TEST_FILECOPYMETHOD") {
+	case "":
+		currentFileCopyMethod = getDefaultOptions("", "").FileCopyMethod // Should be CopyBytes
+	case "CopyBytes":
+		currentFileCopyMethod = CopyBytes
+	}
+
+	// Allow running all the tests with a different FileCopyMethod.
+	// We want to re-use tests designed for CopyBytes with other copy methods
+	// to make sure that they behave the same way (where possible).
+	overrideDefaultOptions_FOR_TESTS = func(defopt *Options) {
+		defopt.FileCopyMethod = currentFileCopyMethod
+	}
+}
+
 func TestMain(m *testing.M) {
 	setup(m)
+	setupFileCopyMethod(m)
 	code := m.Run()
 	teardown(m)
 	os.Exit(code)

--- a/all_test.go
+++ b/all_test.go
@@ -370,7 +370,6 @@ func TestOptions_PreserveOwner(t *testing.T) {
 }
 
 func TestOptions_CopyRateLimit(t *testing.T) {
-
 	file, err := os.Create("test/data/case16/large.file")
 	if err != nil {
 		t.Errorf("failed to create test file: %v", err)
@@ -391,8 +390,13 @@ func TestOptions_CopyRateLimit(t *testing.T) {
 	start := time.Now()
 	err = Copy("test/data/case16", "test/data.copy/case16", opt)
 	elapsed := time.Since(start)
-	Expect(t, err).ToBe(nil)
-	Expect(t, elapsed > 5*time.Second).ToBe(true)
+	if currentFileCopyMethod.supportsOptWrapReader {
+		Expect(t, err).ToBe(nil)
+		Expect(t, elapsed > 5*time.Second).ToBe(true)
+	} else {
+		Expect(t, err).Not().ToBe(nil)
+		Expect(t, errors.Is(err, ErrUnsupportedCopyMethod)).ToBe(true)
+	}
 }
 
 func TestOptions_OnFileError(t *testing.T) {

--- a/copy_methods.go
+++ b/copy_methods.go
@@ -15,6 +15,8 @@ var ErrUnsupportedCopyMethod = errors.New(
 // CopyBytes copies the file contents by reading the source file into a buffer,
 // then writing the buffer back to the destination file.
 var CopyBytes = FileCopyMethod{
+	supportsOptFS:         true,
+	supportsOptWrapReader: true,
 	fcopy: func(src, dest string, info os.FileInfo, opt Options) (err error, skipFile bool) {
 		var readcloser io.ReadCloser
 		if opt.FS != nil {

--- a/options.go
+++ b/options.go
@@ -132,6 +132,9 @@ const (
 // FileCopyMethod represents one of the ways that a regular file can be copied.
 type FileCopyMethod struct {
 	fcopy func(src, dest string, info os.FileInfo, opt Options) (err error, skipFile bool)
+
+	supportsOptFS         bool
+	supportsOptWrapReader bool
 }
 
 // getDefaultOptions provides default options,

--- a/options.go
+++ b/options.go
@@ -140,7 +140,7 @@ type FileCopyMethod struct {
 // getDefaultOptions provides default options,
 // which would be modified by usage-side.
 func getDefaultOptions(src, dest string) Options {
-	return Options{
+	defopt := Options{
 		OnSymlink: func(string) SymlinkAction {
 			return Shallow // Do shallow copy
 		},
@@ -157,7 +157,18 @@ func getDefaultOptions(src, dest string) Options {
 		WrapReader:        nil,                // Do not wrap src files, use them as they are.
 		intent:            intent{src, dest, nil, nil},
 	}
+
+	if overrideDefaultOptions_FOR_TESTS != nil {
+		overrideDefaultOptions_FOR_TESTS(&defopt)
+	}
+
+	return defopt
 }
+
+// overrideDefaultOptions_FOR_TESTS allows the copy package tests to replace
+// the default options. This allows existing test code to be reused with
+// different settings as a way to check that behavior is consistent.
+var overrideDefaultOptions_FOR_TESTS func(*Options)
 
 // assureOptions struct, should be called only once.
 // All optional values MUST NOT BE nil/zero after assured.


### PR DESCRIPTION
~~**This commit is stacked on top of #164. That must be reviewed and merged first.**~~

## Reason

To prevent regressions, we want good test coverage no matter the `FileCopyMethod` used. We also want to make sure other `FileCopyMethod`s behave like `CopyBytes` when successful for consistency.

Instead of writing many tests to check the behaviour is the same, we re-use existing tests to check that other `FileCopyMethod`s work like `CopyBytes`. The CI runs then runs these tests so the developer does not need different operating systems and the right filesystems installed.

## Details

This series of commits changes the CI and testing so that:

 - The default `FileCopyMethod` can be changed **just in tests** using an environment variable.
 - The CI has more OS variants for using specific filesystems.
    - e.g. `btrfs` for testing copy-on-write (aka reflink)
 - The CI can choose which `FileCopyMethod` to use.

## Example

[This](https://github.com/eth-p/forked-copy/actions/runs/10543146003/job/29210759076) was a run to ensure the copy-on-write (reflink) implementation works.

Previous runs helped me catch a couple edge cases:

 - `opt.FS != nil`
 - `opt.WrapReader != nil`

That would not have been as easy without these changes.