### PR TITLE
Windows junction handling for Go 1.23+

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -53,7 +53,7 @@ func switchboard(src, dest string, info os.FileInfo, opt Options) (err error) {
 	}
 
 	switch {
-	case info.Mode()&os.ModeSymlink != 0:
+	case info.Mode()&os.ModeSymlink != 0 || info.Mode()&os.ModeIrregular != 0:
 		err = onsymlink(src, dest, opt)
 	case info.IsDir():
 		err = dcopy(src, dest, info, opt)


### PR DESCRIPTION
Go 1.23 changed the junction handling on Windows. Junctions are no longer reported with the `os.ModeSymlink` bit set. Instead, they set the `os.ModeIrregular`.

This PR makes the the copy function correctly copy the junctions again, like it used to do before Go 1.23 instead of returning an error.